### PR TITLE
Fix the Swift 6 build and get the test suite running

### DIFF
--- a/Sources/EdgeControl/UI/DashboardShell.swift
+++ b/Sources/EdgeControl/UI/DashboardShell.swift
@@ -185,8 +185,12 @@ struct DashboardShell: View {
                 activeColor: accent,
                 registry: model.touchService.zoneRegistry
             ) {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    editMode.toggle()
+                // The zone registry runs actions on the main actor, but the
+                // closure itself is @Sendable, so hop explicitly for Swift 6.
+                Task { @MainActor in
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        editMode.toggle()
+                    }
                 }
             }
             .overlay {

--- a/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
@@ -167,13 +167,7 @@ private struct ClockContainer: View {
                     Circle().stroke(primary.opacity(0.2), lineWidth: 2)
                     // Hour ticks
                     ForEach(0..<12, id: \.self) { i in
-                        let angle = Double(i) / 12 * 2 * .pi - .pi / 2
-                        let inner = r * (i % 3 == 0 ? 0.75 : 0.85)
-                        Path { p in
-                            p.move(to: CGPoint(x: center.x + cos(angle) * inner, y: center.y + sin(angle) * inner))
-                            p.addLine(to: CGPoint(x: center.x + cos(angle) * r, y: center.y + sin(angle) * r))
-                        }
-                        .stroke(i % 3 == 0 ? primary.opacity(0.6) : Theme.text3(ts), lineWidth: i % 3 == 0 ? 2 : 1)
+                        hourTick(i, center: center, r: r)
                     }
                     // Hour hand
                     clockHand(center: center, length: r * 0.5, width: 3,
@@ -208,6 +202,21 @@ private struct ClockContainer: View {
                 }
             }
         }
+    }
+
+    // Extracted from analogStyle's ZStack: inline, the mixed CGFloat/Double
+    // arithmetic pushes the type checker past its expression time limit on
+    // Xcode 16.4's Swift compiler.
+    private func hourTick(_ i: Int, center: CGPoint, r: CGFloat) -> some View {
+        let angle = Double(i) / 12 * 2 * .pi - .pi / 2
+        let inner = r * (i % 3 == 0 ? 0.75 : 0.85)
+        let cosA = CGFloat(cos(angle))
+        let sinA = CGFloat(sin(angle))
+        return Path { p in
+            p.move(to: CGPoint(x: center.x + cosA * inner, y: center.y + sinA * inner))
+            p.addLine(to: CGPoint(x: center.x + cosA * r, y: center.y + sinA * r))
+        }
+        .stroke(i % 3 == 0 ? primary.opacity(0.6) : Theme.text3(ts), lineWidth: i % 3 == 0 ? 2 : 1)
     }
 
     private func clockHand(center: CGPoint, length: CGFloat, width: CGFloat, angle: Double, color: Color) -> some View {

--- a/Sources/EdgeControl/Widgets/Plugin/PluginWebWidget.swift
+++ b/Sources/EdgeControl/Widgets/Plugin/PluginWebWidget.swift
@@ -816,9 +816,14 @@ private struct PluginWebViewRepresentable: NSViewRepresentable {
 
             Task {
                 let center = UNUserNotificationCenter.current()
-                let settings = await center.notificationSettings()
+                // UNNotificationSettings is not Sendable, so extract the one
+                // needed value via the completion-handler API instead of
+                // sending the settings object across isolation.
+                let status = await withCheckedContinuation { (continuation: CheckedContinuation<UNAuthorizationStatus, Never>) in
+                    center.getNotificationSettings { continuation.resume(returning: $0.authorizationStatus) }
+                }
 
-                switch settings.authorizationStatus {
+                switch status {
                 case .authorized, .provisional:
                     break
                 case .notDetermined:

--- a/Sources/EdgeControlWidgets/Providers/PluginWidgetProvider.swift
+++ b/Sources/EdgeControlWidgets/Providers/PluginWidgetProvider.swift
@@ -55,7 +55,9 @@ struct PluginWidgetEntry: TimelineEntry, Sendable {
     let date: Date
     let pluginId: String?
     let pluginName: String?
-    let snapshotImage: NSImage?
+    // NSImage is not Sendable; entries are only ever built and consumed on the
+    // main actor, so suppress the check rather than drop the conformance.
+    nonisolated(unsafe) let snapshotImage: NSImage?
     let isPlaceholder: Bool
 
     static let placeholder = PluginWidgetEntry(

--- a/Tests/EdgeControlTests/CI/RateLimitTrackingTransportTests.swift
+++ b/Tests/EdgeControlTests/CI/RateLimitTrackingTransportTests.swift
@@ -72,7 +72,7 @@ final class RateLimitTrackingTransportTests: XCTestCase {
         XCTAssertNil(a.rateLimit(forHost: "git.example.dev"))
     }
 
-    func testSettingsRendersQuotaWithReset() {
+    @MainActor func testSettingsRendersQuotaWithReset() {
         // Fixed `now`, so the assertion cannot depend on how long the test took
         // to reach this line.
         let now = Date(timeIntervalSince1970: 1_800_000_000)
@@ -89,7 +89,7 @@ final class RateLimitTrackingTransportTests: XCTestCase {
     }
 
     /// Under a minute must read as "resetting", not "0m".
-    func testQuotaResetWithinAMinute() {
+    @MainActor func testQuotaResetWithinAMinute() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let soon = CIRateLimit(limit: 60, remaining: 0, resetsAt: now.addingTimeInterval(20))
         XCTAssertEqual(CICDSettingsView.quotaText(soon, now: now), "0/60 · resetting")

--- a/Tests/EdgeControlTests/LayoutEngineTests.swift
+++ b/Tests/EdgeControlTests/LayoutEngineTests.swift
@@ -10,8 +10,10 @@ final class LayoutEngineTests: XCTestCase {
     private var engine: LayoutEngine!
     private var pageId: String!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    // XCTest's throwing set-up hooks are nonisolated, so on a @MainActor
+    // test case they cannot touch the main-actor state they exist to build.
+    // The async hooks inherit the class's isolation, so use those instead.
+    override func setUp() async throws {
         directory = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("LayoutEngineTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -22,11 +24,10 @@ final class LayoutEngineTests: XCTestCase {
         pageId = engine.document.pages[0].id
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() async throws {
         engine = nil
         try? FileManager.default.removeItem(at: directory)
         directory = nil
-        try super.tearDownWithError()
     }
 
     private var widgets: [WidgetPlacement] { engine.document.pages[0].widgets }


### PR DESCRIPTION
## Stack 1 of 7 — no dependencies, mergeable on its own

**This one is independent of the rest of the stack and fixes a build failure on `main`.** If you merge nothing else, this is the one worth taking.

### The problem

`main` does not compile on current Xcode/Swift 6:

```
Sources/EdgeControlWidgets/Providers/PluginWidgetProvider.swift:58:9: error:
stored property 'snapshotImage' of 'Sendable'-conforming struct
'PluginWidgetEntry' has non-sendable type 'NSImage?'
```

Separately, the **test target never compiled at all**, so `xcodebuild test` could not run the suite. Two distinct isolation errors:

- tests calling the main-actor-isolated `CICDSettingsView.quotaText` from nonisolated test methods
- `LayoutEngineTests` building main-actor fixtures inside `setUpWithError` / `tearDownWithError`, whose XCTest signatures stay nonisolated even on a `@MainActor` test case

### The fix

Make the app target Sendable-clean, annotate the two quota tests `@MainActor`, and move the layout fixtures to the async set-up hooks, which do inherit the class's isolation. The `super` calls go with them — awaiting the non-Sendable superclass across the actor hop is itself an error, and XCTest already invokes the empty base implementations.

### Verification

```
** BUILD SUCCEEDED **
** TEST SUCCEEDED **  Executed 87 tests, with 0 failures
```

Those 87 tests had not been executed before this change, since the target did not build.

---

Part of a 7-PR stack; the rest builds on this one. Because GitHub requires a PR base to live in this repo, every PR in the stack targets `main`, so PRs 2–7 will show their ancestors' commits until the earlier ones merge.
