### PR TITLE
CI/CD Runs: show workflow names, one row per workflow

### DIFF
--- a/Sources/EdgeControl/UI/DashboardShell.swift
+++ b/Sources/EdgeControl/UI/DashboardShell.swift
@@ -185,8 +185,12 @@ struct DashboardShell: View {
                 activeColor: accent,
                 registry: model.touchService.zoneRegistry
             ) {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    editMode.toggle()
+                // The zone registry runs actions on the main actor, but the
+                // closure itself is @Sendable, so hop explicitly for Swift 6.
+                Task { @MainActor in
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        editMode.toggle()
+                    }
                 }
             }
             .overlay {

--- a/Sources/EdgeControl/UI/Settings/CICDSettingsView.swift
+++ b/Sources/EdgeControl/UI/Settings/CICDSettingsView.swift
@@ -16,6 +16,23 @@ struct CICDSettingsView: View {
     @State private var importError: String?
 
     private var service: CICDService { model.cicdService }
+
+    /// Repositories currently contributing runs to the widget, ready to hide.
+    /// run.id is "<accountID>/<owner>/<name>/<run number>".
+    private var shownRepositories: [CIRepositoryRef] {
+        let hidden = service.settings.hiddenRepositories
+        var seen = Set<CIRepositoryRef>()
+        var result: [CIRepositoryRef] = []
+        for run in service.runs {
+            let parts = run.id.split(separator: "/")
+            guard parts.count >= 4,
+                  let accountID = UUID(uuidString: String(parts[0])),
+                  let host = store.accounts.first(where: { $0.id == accountID })?.host else { continue }
+            let ref = CIRepositoryRef(host: host, fullName: parts.dropFirst().dropLast().joined(separator: "/"))
+            if !hidden.contains(ref), seen.insert(ref).inserted { result.append(ref) }
+        }
+        return result.sorted()
+    }
     private var store: CIAccountStore { model.accountStore }
 
     private var cliAvailable: Bool {
@@ -246,6 +263,22 @@ struct CICDSettingsView: View {
                 host: $hiddenHost,
                 text: $hiddenDraft
             )
+
+            // The typed entry above requires knowing the exact owner/name;
+            // this menu offers exactly what the widget is showing right now.
+            if !shownRepositories.isEmpty {
+                Menu {
+                    ForEach(shownRepositories, id: \.self) { ref in
+                        Button(ref.displayName) {
+                            service.settings.hiddenRepositories.insert(ref)
+                        }
+                    }
+                } label: {
+                    Label("Hide a repository currently shown…", systemImage: "eye.slash")
+                        .font(Theme.label(ts))
+                }
+                .frame(maxWidth: 320)
+            }
         }
     }
 

--- a/Sources/EdgeControl/Widgets/DevTools/CICDRunsWidget.swift
+++ b/Sources/EdgeControl/Widgets/DevTools/CICDRunsWidget.swift
@@ -190,6 +190,13 @@ private struct CICDRunsWidgetView: View {
                             .font(Theme.label(ts))
                             .foregroundStyle(Theme.text3(ts).opacity(0.6))
                     }
+                    // One commit can fan out to several workflows, and some runs
+                    // share a constant title ("pages build and deployment"), so
+                    // without the workflow name such rows are indistinguishable.
+                    Text("· \(run.workflowName)")
+                        .font(Theme.label(ts))
+                        .foregroundStyle(Theme.text3(ts).opacity(0.6))
+                        .lineLimit(1)
                 }
                 Text(run.title)
                     .font(Theme.body(ts))

--- a/Sources/EdgeControl/Widgets/DevTools/CICDRunsWidget.swift
+++ b/Sources/EdgeControl/Widgets/DevTools/CICDRunsWidget.swift
@@ -90,6 +90,41 @@ private struct CICDRunsWidgetView: View {
         )
     }
 
+    /// Latest run per (account, repository, workflow). The widget is a status
+    /// board, not an activity log: re-runs and repeat deployments (Pages runs
+    /// all share one title) collapse to the workflow's current state.
+    private func latestPerWorkflow(_ runs: [CIRun]) -> [CIRun] {
+        var latest: [String: CIRun] = [:]
+        for run in runs {
+            // run.id is "<accountID>/<repo full name>/<run number>"; dropping
+            // the run number yields a key that survives same-named repos in
+            // different orgs, which repositoryName (the short name) would not.
+            let repoKey = run.id[..<(run.id.lastIndex(of: "/") ?? run.id.endIndex)]
+            let key = "\(repoKey)|\(run.workflowName)"
+            if let existing = latest[key], existing.startedAt >= run.startedAt { continue }
+            latest[key] = run
+        }
+        return latest.values.sorted { $0.startedAt > $1.startedAt }
+    }
+
+    /// The header badge counts what the list shows: distinct workflows, not
+    /// raw runs, once collapsing is in effect.
+    private var headerCount: Int {
+        if case .runs(let runs, _) = state { return latestPerWorkflow(runs).count }
+        return service.runs.count
+    }
+
+    /// Compact age label ("2h"). Empty for runs whose start time is unknown
+    /// (the provider falls back to .distantPast).
+    private func relativeAge(_ date: Date) -> String {
+        guard date != .distantPast else { return "" }
+        let seconds = max(0, Date().timeIntervalSince(date))
+        if seconds < 60 { return "now" }
+        if seconds < 3600 { return "\(Int(seconds / 60))m" }
+        if seconds < 86400 { return "\(Int(seconds / 3600))h" }
+        return "\(Int(seconds / 86400))d"
+    }
+
     var body: some View {
         VStack(spacing: 6) {
             header
@@ -123,7 +158,7 @@ private struct CICDRunsWidgetView: View {
                         Task { @MainActor in SettingsWindowController.shared.show() }
                     }
             }
-            Text("\(service.runs.count)")
+            Text("\(headerCount)")
                 .font(Theme.body(ts))
                 .foregroundStyle(Theme.text3(ts))
         }
@@ -152,7 +187,7 @@ private struct CICDRunsWidgetView: View {
             // the list to 50.
             TouchScrollView {
                 VStack(spacing: 4) {
-                    ForEach(runs) { run in
+                    ForEach(latestPerWorkflow(runs)) { run in
                         runRow(run)
                     }
                 }
@@ -204,6 +239,9 @@ private struct CICDRunsWidgetView: View {
                     .lineLimit(1)
             }
             Spacer()
+            Text(relativeAge(run.startedAt))
+                .font(Theme.label(ts))
+                .foregroundStyle(Theme.text3(ts).opacity(0.7))
             Text(statusLabel(run))
                 .font(Theme.label(ts))
                 .foregroundStyle(statusColor(run))

--- a/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
@@ -167,13 +167,7 @@ private struct ClockContainer: View {
                     Circle().stroke(primary.opacity(0.2), lineWidth: 2)
                     // Hour ticks
                     ForEach(0..<12, id: \.self) { i in
-                        let angle = Double(i) / 12 * 2 * .pi - .pi / 2
-                        let inner = r * (i % 3 == 0 ? 0.75 : 0.85)
-                        Path { p in
-                            p.move(to: CGPoint(x: center.x + cos(angle) * inner, y: center.y + sin(angle) * inner))
-                            p.addLine(to: CGPoint(x: center.x + cos(angle) * r, y: center.y + sin(angle) * r))
-                        }
-                        .stroke(i % 3 == 0 ? primary.opacity(0.6) : Theme.text3(ts), lineWidth: i % 3 == 0 ? 2 : 1)
+                        hourTick(i, center: center, r: r)
                     }
                     // Hour hand
                     clockHand(center: center, length: r * 0.5, width: 3,
@@ -208,6 +202,21 @@ private struct ClockContainer: View {
                 }
             }
         }
+    }
+
+    // Extracted from analogStyle's ZStack: inline, the mixed CGFloat/Double
+    // arithmetic pushes the type checker past its expression time limit on
+    // Xcode 16.4's Swift compiler.
+    private func hourTick(_ i: Int, center: CGPoint, r: CGFloat) -> some View {
+        let angle = Double(i) / 12 * 2 * .pi - .pi / 2
+        let inner = r * (i % 3 == 0 ? 0.75 : 0.85)
+        let cosA = CGFloat(cos(angle))
+        let sinA = CGFloat(sin(angle))
+        return Path { p in
+            p.move(to: CGPoint(x: center.x + cosA * inner, y: center.y + sinA * inner))
+            p.addLine(to: CGPoint(x: center.x + cosA * r, y: center.y + sinA * r))
+        }
+        .stroke(i % 3 == 0 ? primary.opacity(0.6) : Theme.text3(ts), lineWidth: i % 3 == 0 ? 2 : 1)
     }
 
     private func clockHand(center: CGPoint, length: CGFloat, width: CGFloat, angle: Double, color: Color) -> some View {

--- a/Sources/EdgeControl/Widgets/Plugin/PluginWebWidget.swift
+++ b/Sources/EdgeControl/Widgets/Plugin/PluginWebWidget.swift
@@ -816,9 +816,14 @@ private struct PluginWebViewRepresentable: NSViewRepresentable {
 
             Task {
                 let center = UNUserNotificationCenter.current()
-                let settings = await center.notificationSettings()
+                // UNNotificationSettings is not Sendable, so extract the one
+                // needed value via the completion-handler API instead of
+                // sending the settings object across isolation.
+                let status = await withCheckedContinuation { (continuation: CheckedContinuation<UNAuthorizationStatus, Never>) in
+                    center.getNotificationSettings { continuation.resume(returning: $0.authorizationStatus) }
+                }
 
-                switch settings.authorizationStatus {
+                switch status {
                 case .authorized, .provisional:
                     break
                 case .notDetermined:

--- a/Sources/EdgeControlWidgets/Providers/PluginWidgetProvider.swift
+++ b/Sources/EdgeControlWidgets/Providers/PluginWidgetProvider.swift
@@ -55,7 +55,9 @@ struct PluginWidgetEntry: TimelineEntry, Sendable {
     let date: Date
     let pluginId: String?
     let pluginName: String?
-    let snapshotImage: NSImage?
+    // NSImage is not Sendable; entries are only ever built and consumed on the
+    // main actor, so suppress the check rather than drop the conformance.
+    nonisolated(unsafe) let snapshotImage: NSImage?
     let isPlaceholder: Bool
 
     static let placeholder = PluginWidgetEntry(

--- a/Tests/EdgeControlTests/CI/RateLimitTrackingTransportTests.swift
+++ b/Tests/EdgeControlTests/CI/RateLimitTrackingTransportTests.swift
@@ -72,7 +72,7 @@ final class RateLimitTrackingTransportTests: XCTestCase {
         XCTAssertNil(a.rateLimit(forHost: "git.example.dev"))
     }
 
-    func testSettingsRendersQuotaWithReset() {
+    @MainActor func testSettingsRendersQuotaWithReset() {
         // Fixed `now`, so the assertion cannot depend on how long the test took
         // to reach this line.
         let now = Date(timeIntervalSince1970: 1_800_000_000)
@@ -89,7 +89,7 @@ final class RateLimitTrackingTransportTests: XCTestCase {
     }
 
     /// Under a minute must read as "resetting", not "0m".
-    func testQuotaResetWithinAMinute() {
+    @MainActor func testQuotaResetWithinAMinute() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let soon = CIRateLimit(limit: 60, remaining: 0, resetsAt: now.addingTimeInterval(20))
         XCTAssertEqual(CICDSettingsView.quotaText(soon, now: now), "0/60 · resetting")

--- a/Tests/EdgeControlTests/LayoutEngineTests.swift
+++ b/Tests/EdgeControlTests/LayoutEngineTests.swift
@@ -10,8 +10,10 @@ final class LayoutEngineTests: XCTestCase {
     private var engine: LayoutEngine!
     private var pageId: String!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    // XCTest's throwing set-up hooks are nonisolated, so on a @MainActor
+    // test case they cannot touch the main-actor state they exist to build.
+    // The async hooks inherit the class's isolation, so use those instead.
+    override func setUp() async throws {
         directory = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("LayoutEngineTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -22,11 +24,10 @@ final class LayoutEngineTests: XCTestCase {
         pageId = engine.document.pages[0].id
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() async throws {
         engine = nil
         try? FileManager.default.removeItem(at: directory)
         directory = nil
-        try super.tearDownWithError()
     }
 
     private var widgets: [WidgetPlacement] { engine.document.pages[0].widgets }


### PR DESCRIPTION
## Stack 2 of 7 — builds on #9

**Incremental diff (just this PR's changes):** https://github.com/jondkinney/edgecontrol/compare/pr1-swift6-build...pr2-cicd-runs

### What this does

Makes the CI/CD Runs widget readable when a repo has several workflows:

- **Show the workflow name in each run row.** Previously rows showed only the run, so two workflows on the same repo were indistinguishable.
- **Collapse to the latest run per workflow.** The list repeated the same workflow once per historical run, so a busy repo pushed everything else off the widget. Now each workflow contributes its most recent run.
- **Offer the currently shown repositories in the hide list**, instead of requiring the name to be typed from memory.

### Verification

`** TEST SUCCEEDED **` — 87 tests, 0 failures.

---

Targets `main` because GitHub requires a PR base in this repo; until #9 merges this diff also contains its commits. Use the compare link above for this PR's own changes.
