### PR TITLE
Add a Sticky Note widget with in-place rich text

### DIFF
--- a/EdgeControl.xcodeproj/project.pbxproj
+++ b/EdgeControl.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		02C16759451A6E571B9F6829 /* forgejo-user.json in Resources */ = {isa = PBXBuildFile; fileRef = 66ACE587D08F9C6516970671 /* forgejo-user.json */; };
 		067C54301124CFF84023C648 /* MemoryGaugeWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8970EF907C0D991C1455F7FA /* MemoryGaugeWidget.swift */; };
 		06867F8686B539AF89A5EEC9 /* BluetoothService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322BB0E114232C4FC2E95B0A /* BluetoothService.swift */; };
+		07508AB43A1B55F9C284333E /* GuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E4A193EE27CE99A8FEB5790 /* GuideView.swift */; };
 		07F22FD2B6C31A550078652C /* CIRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AD8E3A956E53382040795B3 /* CIRun.swift */; };
 		09FEB2BFDC20840124FA3084 /* GitHubProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22D3935E121EFF55DA69626 /* GitHubProviderTests.swift */; };
 		0A7DDFD4973B48992791445A /* CICDWidgetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460BB08A24CC6C1DC523BEBB /* CICDWidgetView.swift */; };
@@ -196,6 +197,7 @@
 		083EBD8A86C58AA57C85CA25 /* CIRunState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIRunState.swift; sourceTree = "<group>"; };
 		0B4C1DBB775FC952E2494BB6 /* UnitSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitSystem.swift; sourceTree = "<group>"; };
 		0CD84835E9C4E1128E590E97 /* CIErrorMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CIErrorMappingTests.swift; sourceTree = "<group>"; };
+		0E4A193EE27CE99A8FEB5790 /* GuideView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GuideView.swift; sourceTree = "<group>"; };
 		0E4EE1FD46B45C00D615B4EB /* NetworkProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkProvider.swift; sourceTree = "<group>"; };
 		0ECA20ADC942310310D2C811 /* PluginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginManager.swift; sourceTree = "<group>"; };
 		1007E7E0D246F5FAE5B23FF2 /* WidgetRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetRegistry.swift; sourceTree = "<group>"; };
@@ -485,6 +487,7 @@
 				A0C0585D4ECBD3C294076FCD /* CICDSettingsView.swift */,
 				5250AA176801A15BCFDC4D67 /* DisplaySettingsView.swift */,
 				926EA238AB64D30E0407B43E /* GeneralSettingsView.swift */,
+				0E4A193EE27CE99A8FEB5790 /* GuideView.swift */,
 				12281DDDF4B06A76D53203CF /* PageManagerView.swift */,
 				67C08C5CA9435270274DCC6A /* PluginManagerView.swift */,
 				FB321E4A1BF145B8BAAE20D5 /* SettingsView.swift */,
@@ -888,6 +891,7 @@
 				7FE584F4A350EF3DAEF2DE5D /* GeneralSettingsView.swift in Sources */,
 				1DFA6EA4E2C0BD5D4AC953B2 /* GitHubProvider.swift in Sources */,
 				69B8C3CBF6982B6FE821A527 /* GridPageView.swift in Sources */,
+				07508AB43A1B55F9C284333E /* GuideView.swift in Sources */,
 				AC62F2C94736CB1DE42C2D1D /* HardwareTouchService.swift in Sources */,
 				EE048F1FD1E1DA49AC106EFE /* HistoryGraphView.swift in Sources */,
 				8D5E5222B55F195D788A6C1F /* LayoutConfig.swift in Sources */,

--- a/EdgeControl.xcodeproj/project.pbxproj
+++ b/EdgeControl.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		16431CC6842AC82817F6E9C2 /* AppLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10418B6B91599F07758AB415 /* AppLog.swift */; };
 		166763F84C72FF0A1C61360A /* SettingsWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA543427009BD3A3885D3DFA /* SettingsWindowController.swift */; };
 		16BB7D94190899C7839C72CD /* PulsingDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D785B83D133CA91BDEC3FF8F /* PulsingDot.swift */; };
+		1859C9AE054890B528C7E6A0 /* StickyNoteWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = E436294F9872E45C67C87BD1 /* StickyNoteWidget.swift */; };
 		1CDB3C0856C7915A2DB6D64C /* BluetoothWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7175879BD7EAFC1CB360F629 /* BluetoothWidget.swift */; };
 		1DFA6EA4E2C0BD5D4AC953B2 /* GitHubProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA75D888D822B244E302D7A0 /* GitHubProvider.swift */; };
 		21D9F1ACCE921F7EF6CD43BA /* CICDSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2240A912641ADEE2291695AB /* CICDSettingsTests.swift */; };
@@ -321,6 +322,7 @@
 		E0A1E5BA2EF262CBAB96AA5F /* NowPlayingWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingWidget.swift; sourceTree = "<group>"; };
 		E148907F28B14BDBA1564F42 /* PluginWidgetRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginWidgetRenderer.swift; sourceTree = "<group>"; };
 		E18C869626E48E882115BBEF /* GridPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GridPageView.swift; sourceTree = "<group>"; };
+		E436294F9872E45C67C87BD1 /* StickyNoteWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickyNoteWidget.swift; sourceTree = "<group>"; };
 		E4E52144F8D00F3651D539D8 /* TouchScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchScrollView.swift; sourceTree = "<group>"; };
 		E5092E6C4ED1EE637B47295B /* PluginDataBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDataBridge.swift; sourceTree = "<group>"; };
 		E74CFD789D359E31C58B617F /* CICDAccountSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CICDAccountSheet.swift; sourceTree = "<group>"; };
@@ -717,6 +719,7 @@
 				C405C399C83734FEF0840A72 /* DayProgressWidget.swift */,
 				F5C3DE287AC52599D26E9642 /* MoonPhaseWidget.swift */,
 				A6DE6D98E3E3EBCA851937B3 /* RemindersWidget.swift */,
+				E436294F9872E45C67C87BD1 /* StickyNoteWidget.swift */,
 				ED9B68226BF6912CE2E69CEB /* WeatherWidget.swift */,
 				C5F0BBCB88FED899455146B4 /* WorldClocksWidget.swift */,
 			);
@@ -932,6 +935,7 @@
 				814C3B299B4CDDDCA0C4BD4C /* SSDTempWidget.swift in Sources */,
 				C95EFF669BFD61A25DBEBC55 /* SettingsView.swift in Sources */,
 				166763F84C72FF0A1C61360A /* SettingsWindowController.swift in Sources */,
+				1859C9AE054890B528C7E6A0 /* StickyNoteWidget.swift in Sources */,
 				6B428F8C3D8786FC9A3A0DAD /* StorageBarsWidget.swift in Sources */,
 				FE102C99FE9EB3BB68BB2947 /* SystemMetrics.swift in Sources */,
 				3A1A9122DA44B67625E6635A /* SystemMetricsService.swift in Sources */,

--- a/EdgeControl.xcodeproj/project.pbxproj
+++ b/EdgeControl.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		3778753DC6875CC5218F99FA /* LayoutEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF99821322AE802740C36545 /* LayoutEngine.swift */; };
 		38681F2D4A5DDA0E68F29E27 /* CredentialImporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F793A9942B72216E001EF72 /* CredentialImporterTests.swift */; };
 		3A1A9122DA44B67625E6635A /* SystemMetricsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D1B46290E2B916CD0C3F458 /* SystemMetricsService.swift */; };
+		3B5AB2488045A4E14D578DFD /* RemindersService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E52671BEC4A97B055697A2 /* RemindersService.swift */; };
 		3C658AE0CCFB9B32E8E5EC78 /* DiskIOService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D6B0E686C7958948D5F219 /* DiskIOService.swift */; };
 		3D282679C726F7C60AE09600 /* CommandRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB84A7F782A653FCC4822AD9 /* CommandRunner.swift */; };
 		3E24A63B4725D72110F46442 /* DiskIOWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A306CDC5CBF2677EFDAEE996 /* DiskIOWidget.swift */; };
@@ -60,6 +61,7 @@
 		5366D4434410CC0EC2B9BB65 /* CICDAccountSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74CFD789D359E31C58B617F /* CICDAccountSheet.swift */; };
 		537A4C6E5FB2382662EDC173 /* ConditionalGETTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A529E3A4FD9911D457E7E090 /* ConditionalGETTransport.swift */; };
 		537CD61475EB89D7FB19E902 /* LayoutEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E43C87A7DE46C0837CA55B /* LayoutEngineTests.swift */; };
+		53A1C6859C90F2726EF97A03 /* RemindersWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6DE6D98E3E3EBCA851937B3 /* RemindersWidget.swift */; };
 		576555CB0A1ECA090B945198 /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59A086B0AFB78148E786B8D /* WeatherService.swift */; };
 		5767982D0BF8C63F5E5F6124 /* PluginDataBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5092E6C4ED1EE637B47295B /* PluginDataBridge.swift */; };
 		5A6AFB8CD86F45A91DCA5CFA /* PluginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ECA20ADC942310310D2C811 /* PluginManager.swift */; };
@@ -245,6 +247,7 @@
 		568231131F33767215953AC1 /* StubTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubTransport.swift; sourceTree = "<group>"; };
 		572E0BB9DAC141A48F068D60 /* CICDProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CICDProvider.swift; sourceTree = "<group>"; };
 		57EB794F2EA34AFA4685C600 /* EdgeControlWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeControlWidgets.swift; sourceTree = "<group>"; };
+		58E52671BEC4A97B055697A2 /* RemindersService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemindersService.swift; sourceTree = "<group>"; };
 		5CD9CB23F45C02FE5C72C355 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		60A1AA058F19A28213132880 /* LayoutStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutStoreTests.swift; sourceTree = "<group>"; };
 		66228D7A3E85B0E4DBD98925 /* PluginStorageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginStorageService.swift; sourceTree = "<group>"; };
@@ -288,6 +291,7 @@
 		A529E3A4FD9911D457E7E090 /* ConditionalGETTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalGETTransport.swift; sourceTree = "<group>"; };
 		A6227C3F76176844E5F7B3D3 /* AppIcon.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = AppIcon.icns; sourceTree = "<group>"; };
 		A6A61687864BFA022B4F4D44 /* DashboardShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardShell.swift; sourceTree = "<group>"; };
+		A6DE6D98E3E3EBCA851937B3 /* RemindersWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemindersWidget.swift; sourceTree = "<group>"; };
 		A83DA180C040E418D3393B87 /* LayoutConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutConfig.swift; sourceTree = "<group>"; };
 		A955201FA0E26CA2A945138B /* AudioDevicesWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDevicesWidget.swift; sourceTree = "<group>"; };
 		AA125AE17E85D450F6A00DD1 /* TempHistoryWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempHistoryWidget.swift; sourceTree = "<group>"; };
@@ -541,6 +545,7 @@
 				66228D7A3E85B0E4DBD98925 /* PluginStorageService.swift */,
 				E148907F28B14BDBA1564F42 /* PluginWidgetRenderer.swift */,
 				9595C9AC45EA3355BE3FA845 /* ProcessMonitorService.swift */,
+				58E52671BEC4A97B055697A2 /* RemindersService.swift */,
 				DF86B9D5B3D367A656132C2A /* SMCService.swift */,
 				4D1B46290E2B916CD0C3F458 /* SystemMetricsService.swift */,
 				C59A086B0AFB78148E786B8D /* WeatherService.swift */,
@@ -711,6 +716,7 @@
 				4178FEFA30A50AD9F77F78F1 /* ClockWidget.swift */,
 				C405C399C83734FEF0840A72 /* DayProgressWidget.swift */,
 				F5C3DE287AC52599D26E9642 /* MoonPhaseWidget.swift */,
+				A6DE6D98E3E3EBCA851937B3 /* RemindersWidget.swift */,
 				ED9B68226BF6912CE2E69CEB /* WeatherWidget.swift */,
 				C5F0BBCB88FED899455146B4 /* WorldClocksWidget.swift */,
 			);
@@ -920,6 +926,8 @@
 				16BB7D94190899C7839C72CD /* PulsingDot.swift in Sources */,
 				B0DC0DE2B4686BD868A4A150 /* RadialGaugeView.swift in Sources */,
 				0C36261A76ADD8D4185C3B95 /* RateLimitTrackingTransport.swift in Sources */,
+				3B5AB2488045A4E14D578DFD /* RemindersService.swift in Sources */,
+				53A1C6859C90F2726EF97A03 /* RemindersWidget.swift in Sources */,
 				8AE3BEA60D3B051B31EBDD80 /* SMCService.swift in Sources */,
 				814C3B299B4CDDDCA0C4BD4C /* SSDTempWidget.swift in Sources */,
 				C95EFF669BFD61A25DBEBC55 /* SettingsView.swift in Sources */,

--- a/Sources/EdgeControl/App/EdgeControlApp.swift
+++ b/Sources/EdgeControl/App/EdgeControlApp.swift
@@ -312,6 +312,10 @@ final class EdgeControlAppDelegate: NSObject, NSApplicationDelegate {
         formatMenu.addItem(strikeItem)
         formatMenu.addItem(.separator())
         formatMenu.addItem(NSMenuItem(title: "Body Text", action: Selector(("resetToBodyText:")), keyEquivalent: "0"))
+        formatMenu.addItem(.separator())
+        // Cmd+= is the key under the + glyph; both read as Cmd+Plus.
+        formatMenu.addItem(NSMenuItem(title: "Bigger", action: Selector(("increaseFontSize:")), keyEquivalent: "="))
+        formatMenu.addItem(NSMenuItem(title: "Smaller", action: Selector(("decreaseFontSize:")), keyEquivalent: "-"))
         formatMenuItem.submenu = formatMenu
         mainMenu.addItem(formatMenuItem)
         return mainMenu

--- a/Sources/EdgeControl/App/EdgeControlApp.swift
+++ b/Sources/EdgeControl/App/EdgeControlApp.swift
@@ -275,6 +275,23 @@ final class EdgeControlAppDelegate: NSObject, NSApplicationDelegate {
         fileMenu.addItem(closeItem)
         fileMenuItem.submenu = fileMenu
         mainMenu.addItem(fileMenuItem)
+
+        // Editing shortcuts are MENU key equivalents on macOS — without an
+        // Edit menu, Cmd+A/C/V/X/Z reach no text field in the whole app.
+        let editMenuItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        let undoItem = NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        editMenu.addItem(undoItem)
+        let redoItem = NSMenuItem(title: "Redo", action: Selector(("redo:")), keyEquivalent: "z")
+        redoItem.keyEquivalentModifierMask = [.command, .shift]
+        editMenu.addItem(redoItem)
+        editMenu.addItem(.separator())
+        editMenu.addItem(NSMenuItem(title: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x"))
+        editMenu.addItem(NSMenuItem(title: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c"))
+        editMenu.addItem(NSMenuItem(title: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v"))
+        editMenu.addItem(NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
+        editMenuItem.submenu = editMenu
+        mainMenu.addItem(editMenuItem)
         return mainMenu
     }
 

--- a/Sources/EdgeControl/App/EdgeControlApp.swift
+++ b/Sources/EdgeControl/App/EdgeControlApp.swift
@@ -311,11 +311,14 @@ final class EdgeControlAppDelegate: NSObject, NSApplicationDelegate {
         strikeItem.keyEquivalentModifierMask = [.command, .shift]
         formatMenu.addItem(strikeItem)
         formatMenu.addItem(.separator())
-        formatMenu.addItem(NSMenuItem(title: "Body Text", action: Selector(("resetToBodyText:")), keyEquivalent: "0"))
+        let bodyTextItem = NSMenuItem(title: "Body Text", action: Selector(("resetToBodyText:")), keyEquivalent: "0")
+        bodyTextItem.keyEquivalentModifierMask = [.command, .shift]
+        formatMenu.addItem(bodyTextItem)
         formatMenu.addItem(.separator())
         // Cmd+= is the key under the + glyph; both read as Cmd+Plus.
         formatMenu.addItem(NSMenuItem(title: "Bigger", action: Selector(("increaseFontSize:")), keyEquivalent: "="))
         formatMenu.addItem(NSMenuItem(title: "Smaller", action: Selector(("decreaseFontSize:")), keyEquivalent: "-"))
+        formatMenu.addItem(NSMenuItem(title: "Default Size", action: Selector(("resetFontSize:")), keyEquivalent: "0"))
         formatMenuItem.submenu = formatMenu
         mainMenu.addItem(formatMenuItem)
         return mainMenu

--- a/Sources/EdgeControl/App/EdgeControlApp.swift
+++ b/Sources/EdgeControl/App/EdgeControlApp.swift
@@ -311,6 +311,9 @@ final class EdgeControlAppDelegate: NSObject, NSApplicationDelegate {
         strikeItem.keyEquivalentModifierMask = [.command, .shift]
         formatMenu.addItem(strikeItem)
         formatMenu.addItem(.separator())
+        // Cmd+Return: the "complete the item" convention (Obsidian, Todoist).
+        formatMenu.addItem(NSMenuItem(title: "Toggle Checked", action: Selector(("toggleChecked:")), keyEquivalent: "\r"))
+        formatMenu.addItem(.separator())
         let bodyTextItem = NSMenuItem(title: "Body Text", action: Selector(("resetToBodyText:")), keyEquivalent: "0")
         bodyTextItem.keyEquivalentModifierMask = [.command, .shift]
         formatMenu.addItem(bodyTextItem)

--- a/Sources/EdgeControl/App/EdgeControlApp.swift
+++ b/Sources/EdgeControl/App/EdgeControlApp.swift
@@ -310,6 +310,8 @@ final class EdgeControlAppDelegate: NSObject, NSApplicationDelegate {
         let strikeItem = NSMenuItem(title: "Strikethrough", action: Selector(("toggleStrikethrough:")), keyEquivalent: "x")
         strikeItem.keyEquivalentModifierMask = [.command, .shift]
         formatMenu.addItem(strikeItem)
+        formatMenu.addItem(.separator())
+        formatMenu.addItem(NSMenuItem(title: "Body Text", action: Selector(("resetToBodyText:")), keyEquivalent: "0"))
         formatMenuItem.submenu = formatMenu
         mainMenu.addItem(formatMenuItem)
         return mainMenu

--- a/Sources/EdgeControl/App/EdgeControlApp.swift
+++ b/Sources/EdgeControl/App/EdgeControlApp.swift
@@ -267,6 +267,14 @@ final class EdgeControlAppDelegate: NSObject, NSApplicationDelegate {
         appMenu.addItem(quitItem)
         appMenuItem.submenu = appMenu
         mainMenu.addItem(appMenuItem)
+
+        let fileMenuItem = NSMenuItem()
+        let fileMenu = NSMenu(title: "File")
+        let closeItem = NSMenuItem(title: "Close Window", action: #selector(NSWindow.performClose(_:)), keyEquivalent: "w")
+        closeItem.keyEquivalentModifierMask = [.command]
+        fileMenu.addItem(closeItem)
+        fileMenuItem.submenu = fileMenu
+        mainMenu.addItem(fileMenuItem)
         return mainMenu
     }
 

--- a/Sources/EdgeControl/App/EdgeControlApp.swift
+++ b/Sources/EdgeControl/App/EdgeControlApp.swift
@@ -292,6 +292,26 @@ final class EdgeControlAppDelegate: NSObject, NSApplicationDelegate {
         editMenu.addItem(NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
         editMenuItem.submenu = editMenu
         mainMenu.addItem(editMenuItem)
+
+        // Bold/Italic ride NSFontManager like the standard Format menu;
+        // Underline goes down the responder chain; Strikethrough is our own
+        // selector on the sticky note's text view.
+        let formatMenuItem = NSMenuItem()
+        let formatMenu = NSMenu(title: "Format")
+        let boldItem = NSMenuItem(title: "Bold", action: #selector(NSFontManager.addFontTrait(_:)), keyEquivalent: "b")
+        boldItem.target = NSFontManager.shared
+        boldItem.tag = Int(NSFontTraitMask.boldFontMask.rawValue)
+        formatMenu.addItem(boldItem)
+        let italicItem = NSMenuItem(title: "Italic", action: #selector(NSFontManager.addFontTrait(_:)), keyEquivalent: "i")
+        italicItem.target = NSFontManager.shared
+        italicItem.tag = Int(NSFontTraitMask.italicFontMask.rawValue)
+        formatMenu.addItem(italicItem)
+        formatMenu.addItem(NSMenuItem(title: "Underline", action: Selector(("underline:")), keyEquivalent: "u"))
+        let strikeItem = NSMenuItem(title: "Strikethrough", action: Selector(("toggleStrikethrough:")), keyEquivalent: "x")
+        strikeItem.keyEquivalentModifierMask = [.command, .shift]
+        formatMenu.addItem(strikeItem)
+        formatMenuItem.submenu = formatMenu
+        mainMenu.addItem(formatMenuItem)
         return mainMenu
     }
 

--- a/Sources/EdgeControl/App/EdgeControlApp.swift
+++ b/Sources/EdgeControl/App/EdgeControlApp.swift
@@ -13,36 +13,33 @@ final class DashboardWindowController {
         history: MetricsHistory,
         pluginManager: PluginManager
     ) {
+        let rootView = AnyView(
+            DashboardShell()
+                .environmentObject(model)
+                .environmentObject(layoutEngine)
+                .environmentObject(registry)
+                .environmentObject(history)
+        )
+
         let dashboardWindow: NSWindow
         if let existing = window {
             dashboardWindow = existing
         } else {
-            let hosting = NSHostingController(
-                rootView: AnyView(
-                    DashboardShell()
-                        .environmentObject(model)
-                        .environmentObject(layoutEngine)
-                        .environmentObject(registry)
-                        .environmentObject(history)
-                )
+            let created = KioskWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 1440, height: 405),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable],
+                backing: .buffered,
+                defer: false
             )
-            let created = KioskWindow(contentViewController: hosting)
             created.title = "EdgeControl"
-            created.styleMask = [.titled, .closable, .miniaturizable, .resizable]
             created.isReleasedWhenClosed = false
-            created.setContentSize(NSSize(width: 1440, height: 405))
+            created.contentView = KioskHostingView(rootView: rootView)
             window = created
             dashboardWindow = created
         }
 
-        if let hosting = dashboardWindow.contentViewController as? NSHostingController<AnyView> {
-            hosting.rootView = AnyView(
-                DashboardShell()
-                    .environmentObject(model)
-                    .environmentObject(layoutEngine)
-                    .environmentObject(registry)
-                    .environmentObject(history)
-            )
+        if let hosting = dashboardWindow.contentView as? KioskHostingView<AnyView> {
+            hosting.rootView = rootView
         }
 
         let placed = WindowPlacement.configure(

--- a/Sources/EdgeControl/App/WindowPlacement.swift
+++ b/Sources/EdgeControl/App/WindowPlacement.swift
@@ -70,6 +70,29 @@ class KioskWindow: NSWindow {
     override var canBecomeMain: Bool { true }
 }
 
+/// Hosts the dashboard and keeps its SwiftUI tree out of the accessibility
+/// hierarchy — the whole dashboard is one opaque group to assistive clients.
+///
+/// SwiftUI builds accessibility elements for a hosting view lazily, the first
+/// time any client walks or hit-tests it, and from then on it re-derives the
+/// attachments for every gesture-bearing element on every render. A full page
+/// is ~400 elements, which is 4–5 ms per frame; a drag renders per pointer
+/// event and turned from smooth into seconds behind the finger. Clients that
+/// do this are everywhere and invisible to the user: text grabbers query the
+/// element under the pointer on every mouse-up, hotkey navigators scan the
+/// front app, window managers enumerate windows. Never handing out children
+/// keeps the tree from ever being materialised, and the widgets remain
+/// operable through the Settings window.
+final class KioskHostingView<Content: View>: NSHostingView<Content> {
+    override func isAccessibilityElement() -> Bool { true }
+    override func accessibilityRole() -> NSAccessibility.Role? { .group }
+    override func accessibilityLabel() -> String? { "EdgeControl dashboard" }
+    override func accessibilityChildren() -> [Any]? { nil }
+    override func accessibilityChildrenInNavigationOrder() -> [any NSAccessibilityElementProtocol]? { nil }
+    override func accessibilityHitTest(_ point: NSPoint) -> Any? { self }
+    override var accessibilityFocusedUIElement: Any? { nil }
+}
+
 struct WindowAccessor: NSViewRepresentable {
     let callback: (NSWindow?) -> Void
 

--- a/Sources/EdgeControl/App/WindowPlacement.swift
+++ b/Sources/EdgeControl/App/WindowPlacement.swift
@@ -24,7 +24,8 @@ public enum WindowPlacement {
         _ window: NSWindow?,
         display: DisplayDescriptor?,
         kioskMode: Bool,
-        strictMonitorAffinity: Bool = false
+        strictMonitorAffinity: Bool = false,
+        allowSystemPanels: Bool = false
     ) -> Bool {
         guard let window else { return false }
 
@@ -56,7 +57,13 @@ public enum WindowPlacement {
         guard let screen = targetScreen else { return false }
 
         window.styleMask = [.borderless]
-        window.level = .statusBar
+        // Paste-class panels present at the menu-bar level (24) on the key
+        // window's screen; at .statusBar (25) the kiosk buries them
+        // invisibly. One notch below lets them through, at the cost of the
+        // menu bar being able to draw over the dashboard.
+        window.level = allowSystemPanels
+            ? NSWindow.Level(NSWindow.Level.mainMenu.rawValue - 1)
+            : .statusBar
         window.collectionBehavior = [.canJoinAllSpaces, .stationary]
         window.setFrame(screen.frame, display: true)
         window.orderFrontRegardless()

--- a/Sources/EdgeControl/Info.plist
+++ b/Sources/EdgeControl/Info.plist
@@ -24,6 +24,10 @@
     <string>public.app-category.utilities</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
+    <key>NSRemindersFullAccessUsageDescription</key>
+    <string>The Reminders widget shows your lists and lets you add and complete reminders from the dashboard.</string>
+    <key>NSRemindersUsageDescription</key>
+    <string>The Reminders widget shows your lists and lets you add and complete reminders from the dashboard.</string>
     <key>NSLocationUsageDescription</key>
     <string>EdgeControl uses your location for accurate weather data on your dashboard.</string>
     <key>NSLocationWhenInUseUsageDescription</key>

--- a/Sources/EdgeControl/Models/LayoutConfig.swift
+++ b/Sources/EdgeControl/Models/LayoutConfig.swift
@@ -136,6 +136,12 @@ public struct GlobalSettings: Codable, Sendable {
     /// without anyone going looking for the setting.
     public var units: UnitSystem
     public var theme: ThemeSettings
+    /// Drops the kiosk window one notch below the menu-bar level, so system
+    /// panels that present there — clipboard managers like Paste, most
+    /// hotkey-summoned pickers — appear above the dashboard instead of being
+    /// invisibly buried behind it. The trade: the kiosk display's menu bar
+    /// can also draw over the dashboard's top edge.
+    public var allowSystemPanels: Bool
 
     public init(
         selectedDisplayName: String? = nil,
@@ -145,7 +151,8 @@ public struct GlobalSettings: Codable, Sendable {
         strictMonitorAffinity: Bool = false,
         hideFromDock: Bool = false,
         units: UnitSystem = .localeDefault,
-        theme: ThemeSettings = ThemeSettings()
+        theme: ThemeSettings = ThemeSettings(),
+        allowSystemPanels: Bool = false
     ) {
         self.selectedDisplayName = selectedDisplayName
         self.kioskMode = kioskMode
@@ -155,11 +162,13 @@ public struct GlobalSettings: Codable, Sendable {
         self.hideFromDock = hideFromDock
         self.units = units
         self.theme = theme
+        self.allowSystemPanels = allowSystemPanels
     }
 
     enum CodingKeys: String, CodingKey {
         case selectedDisplayName, kioskMode, launchAtLogin, debugMode
         case strictMonitorAffinity, hideFromDock, units, theme
+        case allowSystemPanels
     }
 
     // Custom Decodable so existing layout.json files (which don't carry
@@ -176,6 +185,7 @@ public struct GlobalSettings: Codable, Sendable {
         hideFromDock = try c.decodeIfPresent(Bool.self, forKey: .hideFromDock) ?? false
         units = try c.decodeIfPresent(UnitSystem.self, forKey: .units) ?? .localeDefault
         theme = try c.decodeIfPresent(ThemeSettings.self, forKey: .theme) ?? ThemeSettings()
+        allowSystemPanels = try c.decodeIfPresent(Bool.self, forKey: .allowSystemPanels) ?? false
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -188,5 +198,6 @@ public struct GlobalSettings: Codable, Sendable {
         try c.encode(hideFromDock, forKey: .hideFromDock)
         try c.encode(units, forKey: .units)
         try c.encode(theme, forKey: .theme)
+        try c.encode(allowSystemPanels, forKey: .allowSystemPanels)
     }
 }

--- a/Sources/EdgeControl/Models/WidgetProtocol.swift
+++ b/Sources/EdgeControl/Models/WidgetProtocol.swift
@@ -314,6 +314,7 @@ public enum ServiceKey: String, CaseIterable, Hashable, Sendable {
     case diskIO         // DiskIOService
     case process        // ProcessMonitorService
     case cicd           // CICDService — GitHub, Forgejo, any future host
+    case reminders      // RemindersService (EventKit)
 }
 
 // MARK: - Dashboard Widget Protocol

--- a/Sources/EdgeControl/Models/WidgetProtocol.swift
+++ b/Sources/EdgeControl/Models/WidgetProtocol.swift
@@ -361,3 +361,42 @@ extension DashboardWidget {
         return config
     }
 }
+
+// MARK: - Tap-to-Launch
+
+/// Widgets that aren't otherwise interactive can launch an app when tapped
+/// (config key "launchApp"; clearing the field disables it). These are the
+/// out-of-the-box pairings; every other widget starts with none.
+public enum WidgetLaunch {
+    public static let configKey = "launchApp"
+    /// Widgets whose taps already do something keep their behavior.
+    public static let excluded: Set<String> = ["cicd-runs"]
+
+    public static func defaultApp(for widgetId: String) -> String {
+        switch widgetId {
+        case "process-list": "Activity Monitor"
+        case "storage-bars": "DaisyDisk"
+        case "clock": "Calendar"
+        default: ""
+        }
+    }
+
+    /// Launches by app name from the standard app folders; a configured app
+    /// that isn't installed (DaisyDisk, say) falls back to Finder.
+    @MainActor
+    public static func launch(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        let fm = FileManager.default
+        let candidates = [
+            "/Applications/\(trimmed).app",
+            "/System/Applications/\(trimmed).app",
+            "/System/Applications/Utilities/\(trimmed).app",
+        ]
+        if let path = candidates.first(where: { fm.fileExists(atPath: $0) }) {
+            NSWorkspace.shared.openApplication(at: URL(fileURLWithPath: path), configuration: NSWorkspace.OpenConfiguration())
+        } else if trimmed != "Finder" {
+            NSWorkspace.shared.openApplication(at: URL(fileURLWithPath: "/System/Library/CoreServices/Finder.app"), configuration: NSWorkspace.OpenConfiguration())
+        }
+    }
+}

--- a/Sources/EdgeControl/Models/WidgetProtocol.swift
+++ b/Sources/EdgeControl/Models/WidgetProtocol.swift
@@ -369,6 +369,14 @@ extension DashboardWidget {
 /// out-of-the-box pairings; every other widget starts with none.
 public enum WidgetLaunch {
     public static let configKey = "launchApp"
+    /// Extra setting shown only when the launch target is Activity Monitor.
+    public static let tabConfigKey = "launchAppTab"
+    /// Activity Monitor's fixed tab set, in SelectedTab index order.
+    public static let activityMonitorTabs = ["CPU", "Memory", "Energy", "Disk", "Network"]
+
+    public static func isActivityMonitor(_ name: String) -> Bool {
+        name.contains("Activity Monitor")
+    }
     /// Widgets whose taps already do something keep their behavior.
     public static let excluded: Set<String> = ["cicd-runs"]
 
@@ -384,9 +392,16 @@ public enum WidgetLaunch {
     /// Launches by app name from the standard app folders; a configured app
     /// that isn't installed (DaisyDisk, say) falls back to Finder.
     @MainActor
-    public static func launch(_ name: String) {
+    public static func launch(_ name: String, tab: String = "") {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return }
+        // Activity Monitor reads its tab from its own defaults at launch, so
+        // setting SelectedTab first opens the chosen tab — no scripting or
+        // extra permissions. (Already-running instances keep their tab.)
+        if isActivityMonitor(trimmed), let index = activityMonitorTabs.firstIndex(of: tab) {
+            CFPreferencesSetAppValue("SelectedTab" as CFString, index as CFNumber, "com.apple.ActivityMonitor" as CFString)
+            CFPreferencesAppSynchronize("com.apple.ActivityMonitor" as CFString)
+        }
         let fm = FileManager.default
         let candidates = [
             "/Applications/\(trimmed).app",

--- a/Sources/EdgeControl/Models/WidgetProtocol.swift
+++ b/Sources/EdgeControl/Models/WidgetProtocol.swift
@@ -267,6 +267,9 @@ public struct ConfigSchemaEntry: Codable, Hashable, Sendable {
     public let minValue: Double?
     public let maxValue: Double?
     public let step: Double?
+    /// Optional caption rendered under the control explaining what the
+    /// setting actually does.
+    public let help: String?
 
     public init(
         key: String,
@@ -276,7 +279,8 @@ public struct ConfigSchemaEntry: Codable, Hashable, Sendable {
         options: [String]? = nil,
         minValue: Double? = nil,
         maxValue: Double? = nil,
-        step: Double? = nil
+        step: Double? = nil,
+        help: String? = nil
     ) {
         self.key = key
         self.label = label
@@ -286,6 +290,7 @@ public struct ConfigSchemaEntry: Codable, Hashable, Sendable {
         self.minValue = minValue
         self.maxValue = maxValue
         self.step = step
+        self.help = help
     }
 }
 
@@ -296,6 +301,8 @@ public enum ConfigFieldType: String, Codable, Hashable, Sendable {
     case text
     case picker
     case colorPicker
+    /// A time of day, stored as an "HH:mm" string.
+    case time
 }
 
 // MARK: - Service Key

--- a/Sources/EdgeControl/Models/WidgetProtocol.swift
+++ b/Sources/EdgeControl/Models/WidgetProtocol.swift
@@ -403,6 +403,18 @@ public enum WidgetLaunch {
             CFPreferencesAppSynchronize("com.apple.ActivityMonitor" as CFString)
         }
         let fm = FileManager.default
+        // A full path (from Browse… or typed, tilde ok) is used directly.
+        // No quoting concerns: this never touches a shell — NSWorkspace takes
+        // a file URL, and URLs carry spaces natively.
+        let expanded = NSString(string: trimmed).expandingTildeInPath
+        if expanded.hasPrefix("/") {
+            if fm.fileExists(atPath: expanded) {
+                NSWorkspace.shared.openApplication(at: URL(fileURLWithPath: expanded), configuration: NSWorkspace.OpenConfiguration())
+            } else {
+                NSWorkspace.shared.openApplication(at: URL(fileURLWithPath: "/System/Library/CoreServices/Finder.app"), configuration: NSWorkspace.OpenConfiguration())
+            }
+            return
+        }
         let candidates = [
             "/Applications/\(trimmed).app",
             "/System/Applications/\(trimmed).app",

--- a/Sources/EdgeControl/Models/WidgetProtocol.swift
+++ b/Sources/EdgeControl/Models/WidgetProtocol.swift
@@ -386,6 +386,7 @@ public enum WidgetLaunch {
         case "process-list": "Activity Monitor"
         case "storage-bars": "DaisyDisk"
         case "clock": "Calendar"
+        case "reminders": "Reminders"
         default: ""
         }
     }

--- a/Sources/EdgeControl/Services/AppModel.swift
+++ b/Sources/EdgeControl/Services/AppModel.swift
@@ -66,21 +66,9 @@ public final class AppModel: ObservableObject {
         metricsService.start()
         touchService.start()
 
-        // React to touch swipes for page changes
-        touchService.$swipeDirection
-            .compactMap { $0 }
-            .receive(on: RunLoop.main)
-            .sink { [weak self] direction in
-                guard let self else { return }
-                switch direction {
-                case .left:
-                    self.currentPage += 1
-                case .right:
-                    if self.currentPage > 0 { self.currentPage -= 1 }
-                }
-                self.touchService.consumeSwipe()
-            }
-            .store(in: &cancellables)
+        // Page changes ride the live drag stream (liveSwipeDX) straight into
+        // DashboardShell, which owns the decision; a discrete subscription
+        // here would double-navigate.
 
         // Note: other services are started on-demand via updateActiveServices()
     }

--- a/Sources/EdgeControl/Services/AppModel.swift
+++ b/Sources/EdgeControl/Services/AppModel.swift
@@ -22,6 +22,7 @@ public final class AppModel: ObservableObject {
     public let audioService = AudioService()
     public let wifiService = WiFiService()
     public let bluetoothService = BluetoothService()
+    public let remindersService = RemindersService()
     public let accountStore = CIAccountStore()
     public private(set) lazy var cicdService = CICDService(accountStore: accountStore)
     public var widgetDataBridge: WidgetDataBridge?
@@ -130,6 +131,7 @@ public final class AppModel: ObservableObject {
         case .diskIO: return diskIOService
         case .process: return processService
         case .cicd: return cicdService
+        case .reminders: return remindersService
         }
     }
 

--- a/Sources/EdgeControl/Services/HardwareTouchService.swift
+++ b/Sources/EdgeControl/Services/HardwareTouchService.swift
@@ -190,6 +190,10 @@ public final class HardwareTouchService: ObservableObject {
 
     // Touch gesture detection
     @Published public private(set) var swipeDirection: SwipeDirection?
+    /// Live horizontal finger travel in screen points while a drag is in
+    /// progress; nil when no finger is down or the drag is vertical. Lets the
+    /// dashboard track the finger instead of waiting for release.
+    @Published public private(set) var liveSwipeDX: CGFloat?
 
     public enum SwipeDirection: Equatable {
         case left, right
@@ -291,6 +295,19 @@ public final class HardwareTouchService: ObservableObject {
             }
         }
 
+        if sample.pressed, let startPoint = touchStartPoint {
+            let rawPoint = CGPoint(x: sample.x, y: sample.y)
+            if let current = calibration.mappedPoint(for: rawPoint, in: renderBounds) {
+                let dx = current.x - startPoint.x
+                let dy = current.y - startPoint.y
+                // Engage once the drag reads as horizontal; stay engaged
+                // until release so the page doesn't flicker mid-gesture.
+                if liveSwipeDX != nil || (abs(dx) > 12 && abs(dx) > abs(dy) * 1.5) {
+                    liveSwipeDX = dx
+                }
+            }
+        }
+
         if !sample.pressed && wasPressed {
             // Touch release — classify as tap or swipe
             if let startPoint = touchStartPoint,
@@ -314,6 +331,7 @@ public final class HardwareTouchService: ObservableObject {
             }
             touchStartPoint = nil
             touchStartTime = nil
+            liveSwipeDX = nil
         }
 
         previousPressed = sample.pressed

--- a/Sources/EdgeControl/Services/LayoutEngine.swift
+++ b/Sources/EdgeControl/Services/LayoutEngine.swift
@@ -5,27 +5,13 @@ import Foundation
 public final class LayoutEngine: ObservableObject {
     @Published public var document: LayoutDocument
     @Published public var currentPageIndex: Int = 0
-    /// Direction of the next page change; drives the slide transition.
-    /// Published deliberately: SwiftUI animates a removed view with the
-    /// transition recorded at its LAST committed render, so the direction must
-    /// be committed in its own body pass (re-baking the outgoing page's
-    /// transition) before the index moves — see navigate(to:).
-    @Published public private(set) var navigatingForward = true
-
-    /// The one entry point for changing pages. Commits the travel direction
-    /// first, then moves the index on the next runloop tick so both the
-    /// outgoing and incoming pages resolve their transition edges from the
-    /// fresh direction.
+    /// The one entry point for changing pages. With offset-based paging the
+    /// travel direction is pure geometry, so this is a plain clamped set;
+    /// callers wrap it in withAnimation when the move should slide.
     public func navigate(to target: Int) {
         let clamped = min(max(target, 0), max(pageCount - 1, 0))
         guard clamped != currentPageIndex else { return }
-        navigatingForward = clamped >= currentPageIndex
-        // Next runloop tick, not the same transaction: the direction change
-        // must commit its own body pass first. Animation comes from the
-        // shell's .animation(value: currentPageIndex) modifier.
-        Task { @MainActor in
-            self.currentPageIndex = clamped
-        }
+        currentPageIndex = clamped
     }
     /// Increments on every layout mutation (widget add/remove/move). Used to trigger service activation updates.
     @Published public var layoutVersion: Int = 0

--- a/Sources/EdgeControl/Services/LayoutEngine.swift
+++ b/Sources/EdgeControl/Services/LayoutEngine.swift
@@ -38,8 +38,57 @@ public final class LayoutEngine: ObservableObject {
             // Entering a session: persist the clean pre-session state first,
             // so a write debounced moments earlier can't be swallowed by the
             // session's write suppression.
-            if isEditing && !oldValue { flushSave() }
+            if isEditing && !oldValue {
+                flushSave()
+                editBaseline = document
+                layoutUndoStack.removeAll()
+                layoutRedoStack.removeAll()
+            }
+            if !isEditing && oldValue {
+                editBaseline = nil
+                layoutUndoStack.removeAll()
+                layoutRedoStack.removeAll()
+            }
         }
+    }
+
+    // Edit-session history: Esc restores the baseline, Cmd+Z steps through
+    // the session's mutations. Snapshots are whole documents — small, and
+    // immune to operation-inverse bookkeeping bugs.
+    private var editBaseline: LayoutDocument?
+    private var layoutUndoStack: [LayoutDocument] = []
+    private var layoutRedoStack: [LayoutDocument] = []
+
+    /// One undo step per user gesture: layout mutators call this before
+    /// changing the document during an edit session. resolveOverlaps
+    /// deliberately does not — displacement is part of the drop's step.
+    private func recordLayoutUndo() {
+        guard isEditing else { return }
+        layoutUndoStack.append(document)
+        if layoutUndoStack.count > 100 { layoutUndoStack.removeFirst() }
+        layoutRedoStack.removeAll()
+    }
+
+    public func undoLayout() {
+        guard isEditing, let previous = layoutUndoStack.popLast() else { return }
+        layoutRedoStack.append(document)
+        document = previous
+        save()
+    }
+
+    public func redoLayout() {
+        guard isEditing, let next = layoutRedoStack.popLast() else { return }
+        layoutUndoStack.append(document)
+        document = next
+        save()
+    }
+
+    /// Esc: abandon the session — restore the layout as it was when edit
+    /// mode began (always overlap-free, so the session may legally end).
+    public func cancelEditing() {
+        if let editBaseline { document = editBaseline }
+        isEditing = false
+        save()
     }
     /// Current dynamic grid — updated from DashboardShell's GeometryReader.
     @Published public var currentGrid: DynamicGrid = .xeneonDefault
@@ -143,6 +192,7 @@ public final class LayoutEngine: ObservableObject {
             height: height,
             config: config
         )
+        recordLayoutUndo()
         document.pages[pageIdx].widgets.append(placement)
         save()
         return placement.instanceId
@@ -155,6 +205,7 @@ public final class LayoutEngine: ObservableObject {
     public func reorderWidget(pageId: String, instanceId: String, toFront: Bool) {
         guard let pageIdx = pageIndex(for: pageId),
               let widgetIdx = widgetIndex(pageIndex: pageIdx, instanceId: instanceId) else { return }
+        recordLayoutUndo()
         let placement = document.pages[pageIdx].widgets.remove(at: widgetIdx)
         if toFront {
             document.pages[pageIdx].widgets.append(placement)
@@ -166,6 +217,7 @@ public final class LayoutEngine: ObservableObject {
 
     public func removeWidget(pageId: String, instanceId: String) {
         guard let pageIdx = pageIndex(for: pageId) else { return }
+        recordLayoutUndo()
         document.pages[pageIdx].widgets.removeAll { $0.instanceId == instanceId }
         save()
     }
@@ -185,6 +237,7 @@ public final class LayoutEngine: ObservableObject {
         let others = document.pages[pageIdx].widgets.filter { $0.instanceId != instanceId }
         guard isEditing || !others.contains(where: { $0.gridRect.intersects(newRect) }) else { return false }
 
+        recordLayoutUndo()
         document.pages[pageIdx].widgets[widgetIdx].col = toCol
         document.pages[pageIdx].widgets[widgetIdx].row = toRow
         save()
@@ -196,7 +249,10 @@ public final class LayoutEngine: ObservableObject {
     /// widget exactly where the user put it. Relocated widgets never bump
     /// others in turn — they only take genuinely free cells — and anything
     /// that fits nowhere stays overlapped, the normal staged edit state.
-    public func resolveOverlaps(pageId: String, keeping keptId: String) {
+    public func resolveOverlaps(
+        pageId: String, keeping keptId: String,
+        minSize: (String) -> WidgetSize? = { _ in nil }
+    ) {
         guard let pageIdx = pageIndex(for: pageId),
               let kept = document.pages[pageIdx].widgets.first(where: { $0.instanceId == keptId })
         else { return }
@@ -230,6 +286,40 @@ public final class LayoutEngine: ObservableObject {
             if let best {
                 document.pages[pageIdx].widgets[idx].col = best.col
                 document.pages[pageIdx].widgets[idx].row = best.row
+                continue
+            }
+            // No room at full size: shrink toward the widget's minimum,
+            // preferring the largest area that fits, nearest its old spot.
+            guard let minimum = minSize(widget.widgetId) else { continue }
+            var candidates: [(w: Int, h: Int)] = []
+            for w in stride(from: widget.width, through: max(1, minimum.width), by: -1) {
+                for h in stride(from: widget.height, through: max(1, minimum.height), by: -1) {
+                    if w == widget.width && h == widget.height { continue }
+                    candidates.append((w, h))
+                }
+            }
+            candidates.sort { ($0.w * $0.h, min($0.w, $0.h)) > ($1.w * $1.h, min($1.w, $1.h)) }
+            for size in candidates {
+                var fit: (col: Int, row: Int)?
+                var fitDistance = Int.max
+                for row in 0...(currentGrid.rows - size.h) {
+                    for col in 0...(currentGrid.columns - size.w) {
+                        let rect = GridRect(col: col, row: row, width: size.w, height: size.h)
+                        guard !others.contains(where: { $0.gridRect.intersects(rect) }) else { continue }
+                        let distance = abs(col - widget.col) + abs(row - widget.row)
+                        if distance < fitDistance {
+                            fitDistance = distance
+                            fit = (col, row)
+                        }
+                    }
+                }
+                if let fit {
+                    document.pages[pageIdx].widgets[idx].col = fit.col
+                    document.pages[pageIdx].widgets[idx].row = fit.row
+                    document.pages[pageIdx].widgets[idx].width = size.w
+                    document.pages[pageIdx].widgets[idx].height = size.h
+                    break
+                }
             }
         }
         save()
@@ -249,6 +339,7 @@ public final class LayoutEngine: ObservableObject {
         let others = document.pages[pageIdx].widgets.filter { $0.instanceId != instanceId }
         guard isEditing || !others.contains(where: { $0.gridRect.intersects(newRect) }) else { return false }
 
+        recordLayoutUndo()
         document.pages[pageIdx].widgets[widgetIdx].width = newWidth
         document.pages[pageIdx].widgets[widgetIdx].height = newHeight
         save()

--- a/Sources/EdgeControl/Services/LayoutEngine.swift
+++ b/Sources/EdgeControl/Services/LayoutEngine.swift
@@ -7,6 +7,12 @@ public final class LayoutEngine: ObservableObject {
     @Published public var currentPageIndex: Int = 0
     /// Increments on every layout mutation (widget add/remove/move). Used to trigger service activation updates.
     @Published public var layoutVersion: Int = 0
+    /// True while the dashboard is in edit mode. Placement rules relax so
+    /// widgets can overlap as a staging state while rearranging; store writes
+    /// pause until the session ends, and a session cannot end (or flush at
+    /// quit) while overlaps remain, so an overlapping layout is never
+    /// persisted.
+    @Published public var isEditing: Bool = false
     /// Current dynamic grid — updated from DashboardShell's GeometryReader.
     @Published public var currentGrid: DynamicGrid = .xeneonDefault
 
@@ -85,7 +91,7 @@ public final class LayoutEngine: ObservableObject {
         guard rect.fitsInGrid(columns: currentGrid.columns, rows: currentGrid.rows) else { return nil }
 
         let existing = document.pages[pageIdx].widgets
-        guard !existing.contains(where: { $0.gridRect.intersects(rect) }) else { return nil }
+        guard isEditing || !existing.contains(where: { $0.gridRect.intersects(rect) }) else { return nil }
 
         let placement = WidgetPlacement(
             widgetId: widgetId,
@@ -120,7 +126,7 @@ public final class LayoutEngine: ObservableObject {
 
         // Check collision with all other widgets on the page
         let others = document.pages[pageIdx].widgets.filter { $0.instanceId != instanceId }
-        guard !others.contains(where: { $0.gridRect.intersects(newRect) }) else { return false }
+        guard isEditing || !others.contains(where: { $0.gridRect.intersects(newRect) }) else { return false }
 
         document.pages[pageIdx].widgets[widgetIdx].col = toCol
         document.pages[pageIdx].widgets[widgetIdx].row = toRow
@@ -140,7 +146,7 @@ public final class LayoutEngine: ObservableObject {
         guard newRect.fitsInGrid(columns: currentGrid.columns, rows: currentGrid.rows) else { return false }
 
         let others = document.pages[pageIdx].widgets.filter { $0.instanceId != instanceId }
-        guard !others.contains(where: { $0.gridRect.intersects(newRect) }) else { return false }
+        guard isEditing || !others.contains(where: { $0.gridRect.intersects(newRect) }) else { return false }
 
         document.pages[pageIdx].widgets[widgetIdx].width = newWidth
         document.pages[pageIdx].widgets[widgetIdx].height = newHeight
@@ -200,14 +206,43 @@ public final class LayoutEngine: ObservableObject {
     }
 
     /// Check if a specific placement is valid (no collision, within bounds).
+    /// While editing, overlap is a permitted staging state, so only bounds
+    /// disqualify; use `wouldOverlap` to color-code staged collisions.
     public func isValidPlacement(pageId: String, col: Int, row: Int, width: Int, height: Int, excludeInstanceId: String? = nil) -> Bool {
-        guard let pageIdx = pageIndex(for: pageId) else { return false }
+        guard pageIndex(for: pageId) != nil else { return false }
 
         let rect = GridRect(col: col, row: row, width: width, height: height)
         guard rect.fitsInGrid(columns: currentGrid.columns, rows: currentGrid.rows) else { return false }
 
+        return isEditing || !wouldOverlap(pageId: pageId, rect: rect, excludeInstanceId: excludeInstanceId)
+    }
+
+    /// Pure collision query, independent of edit mode.
+    public func wouldOverlap(pageId: String, rect: GridRect, excludeInstanceId: String? = nil) -> Bool {
+        guard let pageIdx = pageIndex(for: pageId) else { return false }
         let widgets = document.pages[pageIdx].widgets.filter { $0.instanceId != excludeInstanceId }
-        return !widgets.contains(where: { $0.gridRect.intersects(rect) })
+        return widgets.contains(where: { $0.gridRect.intersects(rect) })
+    }
+
+    /// Instance ids of widgets that overlap another widget on the page.
+    public func overlappingInstanceIds(pageId: String) -> Set<String> {
+        guard let pageIdx = pageIndex(for: pageId) else { return [] }
+        let widgets = document.pages[pageIdx].widgets
+        var result: Set<String> = []
+        for (i, a) in widgets.enumerated() {
+            for b in widgets[(i + 1)...] where a.gridRect.intersects(b.gridRect) {
+                result.insert(a.instanceId)
+                result.insert(b.instanceId)
+            }
+        }
+        return result
+    }
+
+    /// Whether any page holds overlapping widgets. Document-wide because page
+    /// switching stays live during edit mode, so staged overlaps can sit on a
+    /// page other than the visible one.
+    public var hasOverlaps: Bool {
+        document.pages.contains { !overlappingInstanceIds(pageId: $0.id).isEmpty }
     }
 
     // MARK: - Global Settings
@@ -228,12 +263,19 @@ public final class LayoutEngine: ObservableObject {
         Task { @MainActor in
             try? await Task.sleep(for: .milliseconds(500))
             self.saveScheduled = false
+            // Mid-edit the document may legally hold overlaps; the write
+            // happens when the edit session ends (the exit path calls save()
+            // with isEditing already false).
+            guard !self.isEditing else { return }
             self.store.save(self.document)
         }
     }
 
-    /// Immediately save pending changes (called on app quit).
+    /// Immediately save pending changes (called on app quit). Refuses while
+    /// overlaps exist so a quit mid-edit cannot persist an overlapping
+    /// layout — the file keeps its pre-session state instead.
     public func flushSave() {
+        guard !hasOverlaps else { return }
         store.save(document)
         saveScheduled = false
     }

--- a/Sources/EdgeControl/Services/LayoutEngine.swift
+++ b/Sources/EdgeControl/Services/LayoutEngine.swift
@@ -149,6 +149,21 @@ public final class LayoutEngine: ObservableObject {
     }
 
     /// Remove a widget instance from a page.
+    /// Move a widget to the front or back of its page's stacking order.
+    /// Widgets render in array order, so overlapped widgets can be pulled
+    /// out from under one another while editing.
+    public func reorderWidget(pageId: String, instanceId: String, toFront: Bool) {
+        guard let pageIdx = pageIndex(for: pageId),
+              let widgetIdx = widgetIndex(pageIndex: pageIdx, instanceId: instanceId) else { return }
+        let placement = document.pages[pageIdx].widgets.remove(at: widgetIdx)
+        if toFront {
+            document.pages[pageIdx].widgets.append(placement)
+        } else {
+            document.pages[pageIdx].widgets.insert(placement, at: 0)
+        }
+        save()
+    }
+
     public func removeWidget(pageId: String, instanceId: String) {
         guard let pageIdx = pageIndex(for: pageId) else { return }
         document.pages[pageIdx].widgets.removeAll { $0.instanceId == instanceId }

--- a/Sources/EdgeControl/Services/LayoutEngine.swift
+++ b/Sources/EdgeControl/Services/LayoutEngine.swift
@@ -191,6 +191,50 @@ public final class LayoutEngine: ObservableObject {
         return true
     }
 
+    /// After a drop, move the widgets the dropped widget now covers to
+    /// their nearest free spots (Manhattan distance), keeping the dropped
+    /// widget exactly where the user put it. Relocated widgets never bump
+    /// others in turn — they only take genuinely free cells — and anything
+    /// that fits nowhere stays overlapped, the normal staged edit state.
+    public func resolveOverlaps(pageId: String, keeping keptId: String) {
+        guard let pageIdx = pageIndex(for: pageId),
+              let kept = document.pages[pageIdx].widgets.first(where: { $0.instanceId == keptId })
+        else { return }
+        let keptRect = kept.gridRect
+        let displacedIds = document.pages[pageIdx].widgets
+            .filter { $0.instanceId != keptId && $0.gridRect.intersects(keptRect) }
+            .map(\.instanceId)
+        guard !displacedIds.isEmpty else { return }
+
+        for id in displacedIds {
+            guard let idx = document.pages[pageIdx].widgets.firstIndex(where: { $0.instanceId == id })
+            else { continue }
+            let widget = document.pages[pageIdx].widgets[idx]
+            guard currentGrid.columns >= widget.width, currentGrid.rows >= widget.height else { continue }
+            // Earlier relocations are already in the document, so each
+            // displaced widget sees the true occupancy when it searches.
+            let others = document.pages[pageIdx].widgets.filter { $0.instanceId != id }
+            var best: (col: Int, row: Int)?
+            var bestDistance = Int.max
+            for row in 0...(currentGrid.rows - widget.height) {
+                for col in 0...(currentGrid.columns - widget.width) {
+                    let rect = GridRect(col: col, row: row, width: widget.width, height: widget.height)
+                    guard !others.contains(where: { $0.gridRect.intersects(rect) }) else { continue }
+                    let distance = abs(col - widget.col) + abs(row - widget.row)
+                    if distance < bestDistance {
+                        bestDistance = distance
+                        best = (col, row)
+                    }
+                }
+            }
+            if let best {
+                document.pages[pageIdx].widgets[idx].col = best.col
+                document.pages[pageIdx].widgets[idx].row = best.row
+            }
+        }
+        save()
+    }
+
     /// Resize a widget. Returns true on success.
     @discardableResult
     public func resizeWidget(pageId: String, instanceId: String, newWidth: Int, newHeight: Int) -> Bool {

--- a/Sources/EdgeControl/Services/LayoutEngine.swift
+++ b/Sources/EdgeControl/Services/LayoutEngine.swift
@@ -65,10 +65,24 @@ public final class LayoutEngine: ObservableObject {
 
     public func movePage(id: String, toOrder: Int) {
         guard let index = pageIndex(for: id) else { return }
+        // The dashboard tracks the current page by index into sortedPages, so
+        // remember which page is showing and follow it to its new position —
+        // otherwise reordering silently changes what's on screen.
+        let activeId = currentPage?.id
         let page = document.pages.remove(at: index)
-        let clampedOrder = min(max(toOrder, 0), document.pages.count)
-        document.pages.insert(page, at: clampedOrder)
+        // Normalize to order-sorted before inserting: array position and the
+        // persisted `order` field are usually in lockstep (reindexPages), but
+        // an imported or hand-edited document may disagree, and this method is
+        // user-reachable now.
+        var ordered = document.pages.sorted { $0.order < $1.order }
+        let clampedOrder = min(max(toOrder, 0), ordered.count)
+        ordered.insert(page, at: clampedOrder)
+        document.pages = ordered
         reindexPages()
+        if let activeId, let newIdx = sortedPages.firstIndex(where: { $0.id == activeId }),
+           currentPageIndex != newIdx {
+            currentPageIndex = newIdx
+        }
         save()
     }
 

--- a/Sources/EdgeControl/Services/LayoutEngine.swift
+++ b/Sources/EdgeControl/Services/LayoutEngine.swift
@@ -4,7 +4,15 @@ import Foundation
 @MainActor
 public final class LayoutEngine: ObservableObject {
     @Published public var document: LayoutDocument
-    @Published public var currentPageIndex: Int = 0
+    @Published public var currentPageIndex: Int = 0 {
+        willSet { navigatingForward = newValue >= currentPageIndex }
+    }
+    /// Direction of the last page change; drives the slide transition. Every
+    /// path that changes pages (touch swipe, drag, page dots, page manager)
+    /// assigns currentPageIndex, so the willSet covers them all. Deliberately
+    /// not @Published: the flag must hold its value through the body pass the
+    /// index change triggers, not cause another evaluation mid-animation.
+    public private(set) var navigatingForward = true
     /// Increments on every layout mutation (widget add/remove/move). Used to trigger service activation updates.
     @Published public var layoutVersion: Int = 0
     /// True while the dashboard is in edit mode. Placement rules relax so

--- a/Sources/EdgeControl/Services/LayoutEngine.swift
+++ b/Sources/EdgeControl/Services/LayoutEngine.swift
@@ -3,6 +3,15 @@ import Foundation
 /// Manages grid layout: validates placements, detects collisions, finds available cells.
 @MainActor
 public final class LayoutEngine: ObservableObject {
+    public struct SettingsFocus: Equatable {
+        public let pageId: String
+        public let instanceId: String
+        public init(pageId: String, instanceId: String) {
+            self.pageId = pageId
+            self.instanceId = instanceId
+        }
+    }
+
     @Published public var document: LayoutDocument
     @Published public var currentPageIndex: Int = 0
     /// The one entry point for changing pages. With offset-based paging the
@@ -15,6 +24,10 @@ public final class LayoutEngine: ObservableObject {
     }
     /// Increments on every layout mutation (widget add/remove/move). Used to trigger service activation updates.
     @Published public var layoutVersion: Int = 0
+    /// One-shot deep link from a widget's hover gear into Settings: the
+    /// settings views consume it (Pages tab, page selected, widget row
+    /// scrolled into view) and clear it.
+    @Published public var settingsFocus: SettingsFocus?
     /// True while the dashboard is in edit mode. Placement rules relax so
     /// widgets can overlap as a staging state while rearranging; store writes
     /// pause until the session ends, and a session cannot end (or flush at

--- a/Sources/EdgeControl/Services/LayoutEngine.swift
+++ b/Sources/EdgeControl/Services/LayoutEngine.swift
@@ -4,15 +4,29 @@ import Foundation
 @MainActor
 public final class LayoutEngine: ObservableObject {
     @Published public var document: LayoutDocument
-    @Published public var currentPageIndex: Int = 0 {
-        willSet { navigatingForward = newValue >= currentPageIndex }
+    @Published public var currentPageIndex: Int = 0
+    /// Direction of the next page change; drives the slide transition.
+    /// Published deliberately: SwiftUI animates a removed view with the
+    /// transition recorded at its LAST committed render, so the direction must
+    /// be committed in its own body pass (re-baking the outgoing page's
+    /// transition) before the index moves — see navigate(to:).
+    @Published public private(set) var navigatingForward = true
+
+    /// The one entry point for changing pages. Commits the travel direction
+    /// first, then moves the index on the next runloop tick so both the
+    /// outgoing and incoming pages resolve their transition edges from the
+    /// fresh direction.
+    public func navigate(to target: Int) {
+        let clamped = min(max(target, 0), max(pageCount - 1, 0))
+        guard clamped != currentPageIndex else { return }
+        navigatingForward = clamped >= currentPageIndex
+        // Next runloop tick, not the same transaction: the direction change
+        // must commit its own body pass first. Animation comes from the
+        // shell's .animation(value: currentPageIndex) modifier.
+        Task { @MainActor in
+            self.currentPageIndex = clamped
+        }
     }
-    /// Direction of the last page change; drives the slide transition. Every
-    /// path that changes pages (touch swipe, drag, page dots, page manager)
-    /// assigns currentPageIndex, so the willSet covers them all. Deliberately
-    /// not @Published: the flag must hold its value through the body pass the
-    /// index change triggers, not cause another evaluation mid-animation.
-    public private(set) var navigatingForward = true
     /// Increments on every layout mutation (widget add/remove/move). Used to trigger service activation updates.
     @Published public var layoutVersion: Int = 0
     /// True while the dashboard is in edit mode. Placement rules relax so
@@ -20,7 +34,14 @@ public final class LayoutEngine: ObservableObject {
     /// pause until the session ends, and a session cannot end (or flush at
     /// quit) while overlaps remain, so an overlapping layout is never
     /// persisted.
-    @Published public var isEditing: Bool = false
+    @Published public var isEditing: Bool = false {
+        didSet {
+            // Entering a session: persist the clean pre-session state first,
+            // so a write debounced moments earlier can't be swallowed by the
+            // session's write suppression.
+            if isEditing && !oldValue { flushSave() }
+        }
+    }
     /// Current dynamic grid — updated from DashboardShell's GeometryReader.
     @Published public var currentGrid: DynamicGrid = .xeneonDefault
 

--- a/Sources/EdgeControl/Services/LayoutStore.swift
+++ b/Sources/EdgeControl/Services/LayoutStore.swift
@@ -91,10 +91,12 @@ public final class LayoutStore: Sendable {
 
     // MARK: - Export / Import
 
-    public func exportData() -> Data? {
+    public func exportData(_ document: LayoutDocument? = nil) -> Data? {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let doc = load()
+        // Callers with a live document pass it in; store writes pause during
+        // edit sessions, so the disk copy can lag far behind the screen.
+        let doc = document ?? load()
         return try? encoder.encode(doc)
     }
 

--- a/Sources/EdgeControl/Services/PluginDataBridge.swift
+++ b/Sources/EdgeControl/Services/PluginDataBridge.swift
@@ -98,7 +98,9 @@ public final class PluginDataBridge {
                 ]
 
             case .processes:
-                data["processes"] = model.processService.topProcesses.map { proc in
+                // The widget shows up to 12 now, but the plugin API always delivered
+                // at most 5 — keep that contract stable.
+                data["processes"] = model.processService.topProcesses.prefix(5).map { proc in
                     [
                         "pid": proc.id,
                         "name": proc.name,

--- a/Sources/EdgeControl/Services/ProcessMonitorService.swift
+++ b/Sources/EdgeControl/Services/ProcessMonitorService.swift
@@ -100,8 +100,8 @@ public final class ProcessMonitorService: ObservableObject {
         }
 
         // Sort, take top 5, resolve icons
-        let top5 = Array(results.sorted { $0.cpuPercent > $1.cpuPercent }.prefix(5))
-        resolveIcons(for: top5)
+        let top = Array(results.sorted { $0.cpuPercent > $1.cpuPercent }.prefix(12))
+        resolveIcons(for: top)
     }
 
     /// Resolve app icons on MainActor.

--- a/Sources/EdgeControl/Services/ProcessMonitorService.swift
+++ b/Sources/EdgeControl/Services/ProcessMonitorService.swift
@@ -100,7 +100,7 @@ public final class ProcessMonitorService: ObservableObject {
         }
 
         // Sort, take top 5, resolve icons
-        let top = Array(results.sorted { $0.cpuPercent > $1.cpuPercent }.prefix(12))
+        let top = Array(results.sorted { $0.cpuPercent > $1.cpuPercent }.prefix(16))
         resolveIcons(for: top)
     }
 

--- a/Sources/EdgeControl/Services/RemindersService.swift
+++ b/Sources/EdgeControl/Services/RemindersService.swift
@@ -10,6 +10,8 @@ public final class RemindersService: ObservableObject, ServiceLifecycle {
         public let id: String
         public let title: String
         public let dueDate: Date?
+        public let created: Date?
+        public let modified: Date?
     }
 
     public enum Access { case unknown, granted, denied }
@@ -60,7 +62,10 @@ public final class RemindersService: ObservableObject, ServiceLifecycle {
 
     private var selectedCalendar: EKCalendar? {
         let calendars = store.calendars(for: .reminder)
-        if listName.isEmpty { return store.defaultCalendarForNewReminders() ?? calendars.first }
+        // "default" is the picker's sentinel for the system default list.
+        if listName.isEmpty || listName == "default" {
+            return store.defaultCalendarForNewReminders() ?? calendars.first
+        }
         return calendars.first { $0.title == listName } ?? store.defaultCalendarForNewReminders()
     }
 
@@ -81,7 +86,9 @@ public final class RemindersService: ObservableObject, ServiceLifecycle {
                     Item(
                         id: reminder.calendarItemIdentifier,
                         title: reminder.title ?? "",
-                        dueDate: reminder.dueDateComponents.flatMap { Calendar.current.date(from: $0) }
+                        dueDate: reminder.dueDateComponents.flatMap { Calendar.current.date(from: $0) },
+                        created: reminder.creationDate,
+                        modified: reminder.lastModifiedDate
                     )
                 }
                 .sorted {
@@ -104,13 +111,18 @@ public final class RemindersService: ObservableObject, ServiceLifecycle {
         refresh()
     }
 
-    /// Creates a real reminder in the selected list.
-    public func add(title: String) {
+    /// Creates a real reminder in the selected list, optionally due today.
+    public func add(title: String, dueToday: Bool = false) {
         let trimmed = title.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty, let calendar = selectedCalendar else { return }
         let reminder = EKReminder(eventStore: store)
         reminder.title = trimmed
         reminder.calendar = calendar
+        if dueToday {
+            reminder.dueDateComponents = Calendar.current.dateComponents(
+                [.year, .month, .day], from: Date()
+            )
+        }
         try? store.save(reminder, commit: true)
         refresh()
     }

--- a/Sources/EdgeControl/Services/RemindersService.swift
+++ b/Sources/EdgeControl/Services/RemindersService.swift
@@ -39,7 +39,10 @@ public final class RemindersService: ObservableObject, ServiceLifecycle {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in self?.refresh() }
         }
-        store.requestFullAccessToReminders { [weak self] granted, _ in
+        // NOTE: this completion runs on CalendarAgent's XPC queue. It MUST be
+        // @Sendable so it inherits no main-actor isolation — without it the
+        // Swift 6 executor check traps the moment the callback arrives.
+        store.requestFullAccessToReminders { @Sendable [weak self] granted, _ in
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 self.access = granted ? .granted : .denied
@@ -71,7 +74,8 @@ public final class RemindersService: ObservableObject, ServiceLifecycle {
         let predicate = store.predicateForIncompleteReminders(
             withDueDateStarting: nil, ending: nil, calendars: [calendar]
         )
-        store.fetchReminders(matching: predicate) { [weak self] reminders in
+        // Same XPC-queue contract as the access completion above.
+        store.fetchReminders(matching: predicate) { @Sendable [weak self] reminders in
             let mapped = (reminders ?? [])
                 .map { reminder in
                     Item(

--- a/Sources/EdgeControl/Services/RemindersService.swift
+++ b/Sources/EdgeControl/Services/RemindersService.swift
@@ -111,17 +111,19 @@ public final class RemindersService: ObservableObject, ServiceLifecycle {
         refresh()
     }
 
-    /// Creates a real reminder in the selected list, optionally due today.
-    public func add(title: String, dueToday: Bool = false) {
+    /// Creates a real reminder in the selected list, optionally due at a
+    /// specific time (with an alarm, so it actually notifies).
+    public func add(title: String, due: Date? = nil) {
         let trimmed = title.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty, let calendar = selectedCalendar else { return }
         let reminder = EKReminder(eventStore: store)
         reminder.title = trimmed
         reminder.calendar = calendar
-        if dueToday {
+        if let due {
             reminder.dueDateComponents = Calendar.current.dateComponents(
-                [.year, .month, .day], from: Date()
+                [.year, .month, .day, .hour, .minute], from: due
             )
+            reminder.addAlarm(EKAlarm(absoluteDate: due))
         }
         try? store.save(reminder, commit: true)
         refresh()

--- a/Sources/EdgeControl/Services/RemindersService.swift
+++ b/Sources/EdgeControl/Services/RemindersService.swift
@@ -1,0 +1,113 @@
+import EventKit
+import Foundation
+
+/// Live bridge to the system Reminders database (EventKit). Runs only while
+/// a Reminders widget is placed, like every lazily-activated service. First
+/// start triggers the system's Reminders-access prompt.
+@MainActor
+public final class RemindersService: ObservableObject, ServiceLifecycle {
+    public struct Item: Identifiable, Equatable, Sendable {
+        public let id: String
+        public let title: String
+        public let dueDate: Date?
+    }
+
+    public enum Access { case unknown, granted, denied }
+
+    @Published public private(set) var access: Access = .unknown
+    @Published public private(set) var listNames: [String] = []
+    /// Incomplete reminders of the selected list, due-first then by title.
+    @Published public private(set) var items: [Item] = []
+    /// The list to show; empty means the system default list.
+    @Published public var listName: String = "" {
+        didSet { if listName != oldValue { refresh() } }
+    }
+
+    private let store = EKEventStore()
+    private var observer: NSObjectProtocol?
+    private var started = false
+
+    public init() {}
+
+    public func start() {
+        guard !started else { return }
+        started = true
+        // The store posts one notification for any change made anywhere —
+        // the Reminders app, Siri, another device syncing down.
+        observer = NotificationCenter.default.addObserver(
+            forName: .EKEventStoreChanged, object: store, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.refresh() }
+        }
+        store.requestFullAccessToReminders { [weak self] granted, _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.access = granted ? .granted : .denied
+                self.refresh()
+            }
+        }
+    }
+
+    public func stop() {
+        guard started else { return }
+        started = false
+        if let observer { NotificationCenter.default.removeObserver(observer) }
+        observer = nil
+    }
+
+    private var selectedCalendar: EKCalendar? {
+        let calendars = store.calendars(for: .reminder)
+        if listName.isEmpty { return store.defaultCalendarForNewReminders() ?? calendars.first }
+        return calendars.first { $0.title == listName } ?? store.defaultCalendarForNewReminders()
+    }
+
+    public func refresh() {
+        guard access == .granted else { return }
+        listNames = store.calendars(for: .reminder).map(\.title).sorted()
+        guard let calendar = selectedCalendar else {
+            items = []
+            return
+        }
+        let predicate = store.predicateForIncompleteReminders(
+            withDueDateStarting: nil, ending: nil, calendars: [calendar]
+        )
+        store.fetchReminders(matching: predicate) { [weak self] reminders in
+            let mapped = (reminders ?? [])
+                .map { reminder in
+                    Item(
+                        id: reminder.calendarItemIdentifier,
+                        title: reminder.title ?? "",
+                        dueDate: reminder.dueDateComponents.flatMap { Calendar.current.date(from: $0) }
+                    )
+                }
+                .sorted {
+                    switch ($0.dueDate, $1.dueDate) {
+                    case let (a?, b?): return a < b
+                    case (_?, nil): return true
+                    case (nil, _?): return false
+                    default: return $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending
+                    }
+                }
+            Task { @MainActor [weak self] in self?.items = mapped }
+        }
+    }
+
+    /// Completes the reminder everywhere — this writes to the real database.
+    public func complete(id: String) {
+        guard let reminder = store.calendarItem(withIdentifier: id) as? EKReminder else { return }
+        reminder.isCompleted = true
+        try? store.save(reminder, commit: true)
+        refresh()
+    }
+
+    /// Creates a real reminder in the selected list.
+    public func add(title: String) {
+        let trimmed = title.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, let calendar = selectedCalendar else { return }
+        let reminder = EKReminder(eventStore: store)
+        reminder.title = trimmed
+        reminder.calendar = calendar
+        try? store.save(reminder, commit: true)
+        refresh()
+    }
+}

--- a/Sources/EdgeControl/Services/WidgetDataBridge.swift
+++ b/Sources/EdgeControl/Services/WidgetDataBridge.swift
@@ -66,6 +66,14 @@ public final class WidgetDataBridge {
         cancellables.removeAll()
     }
 
+    /// Serial so snapshots land in order; off-main because a wedged
+    /// filesystem operation on the group container once froze the entire UI
+    /// from a main-thread write here.
+    private static let snapshotWriteQueue = DispatchQueue(
+        label: "ai.pakslab.edgecontrol.widget-snapshot",
+        qos: .utility
+    )
+
     /// Debounced write — max once every 30 seconds.
     private func scheduleWrite() {
         guard !writeScheduled else { return }
@@ -121,7 +129,11 @@ public final class WidgetDataBridge {
             unitSystem: layoutEngine.document.globalSettings.units
         )
 
-        data.write()
+        // State is gathered on the main actor above; the file write goes to
+        // a background queue so a slow or stuck disk can never block the UI.
+        Self.snapshotWriteQueue.async {
+            data.write()
+        }
         WidgetCenter.shared.reloadAllTimelines()
     }
 

--- a/Sources/EdgeControl/Services/WidgetRegistry.swift
+++ b/Sources/EdgeControl/Services/WidgetRegistry.swift
@@ -103,6 +103,7 @@ public final class WidgetRegistry: ObservableObject {
         register(ClockWidget())
         register(WorldClocksWidget())
         register(DayProgressWidget())
+        register(RemindersWidget(service: model.remindersService))
         register(MoonPhaseWidget())
 
         // DevTools

--- a/Sources/EdgeControl/Services/WidgetRegistry.swift
+++ b/Sources/EdgeControl/Services/WidgetRegistry.swift
@@ -104,6 +104,7 @@ public final class WidgetRegistry: ObservableObject {
         register(WorldClocksWidget())
         register(DayProgressWidget())
         register(RemindersWidget(service: model.remindersService))
+        register(StickyNoteWidget())
         register(MoonPhaseWidget())
 
         // DevTools

--- a/Sources/EdgeControl/UI/Components/RadialGaugeView.swift
+++ b/Sources/EdgeControl/UI/Components/RadialGaugeView.swift
@@ -36,63 +36,60 @@ struct RadialGaugeView: View {
             // Dampened ratio (0.5x) — gauge already has large proportional sizes, full ratio overshoots.
             let valueRatio = 1.0 + (ts.fontSizeValue / 28.0 - 1.0) * 0.5
             let captionRatio = 1.0 + (ts.fontSizeCaption / 11.0 - 1.0) * 0.5
-            let titleRatio = 1.0 + (ts.fontSizeTitle / 18.0 - 1.0) * 0.5
             let valueFontSize = (isCompact ? minDim * 0.28 : minDim * 0.20) * scale * valueRatio
             let unitFontSize = (isCompact ? minDim * 0.10 : minDim * 0.07) * scale * captionRatio
-            let labelFontSize = (isCompact ? minDim * 0.10 : minDim * 0.08) * scale * titleRatio
+            let labelFontSize = (isCompact ? minDim * 0.09 : minDim * 0.065) * scale * captionRatio
             let lwScaled = isCompact ? lineWidth * 0.7 : lineWidth
             let design = ts.fontFamily.design
 
-            VStack(spacing: isCompact ? 2 : 6) {
-                ZStack {
-                    Circle()
-                        .fill(Theme.glowGradient(gaugeColor))
-                        .scaleEffect(1.3)
-                        .opacity(0.4)
+            // Label lives inside the ring so the arc fills min(width, height) with no caption row below.
+            ZStack {
+                Circle()
+                    .fill(Theme.glowGradient(gaugeColor))
+                    .scaleEffect(1.3)
+                    .opacity(0.4)
 
-                    ArcShape(startAngle: startAngle, endAngle: endAngle)
-                        .stroke(Color.white.opacity(0.08), style: StrokeStyle(lineWidth: lwScaled, lineCap: .round))
+                ArcShape(startAngle: startAngle, endAngle: endAngle)
+                    .stroke(Color.white.opacity(0.08), style: StrokeStyle(lineWidth: lwScaled, lineCap: .round))
 
-                    ArcShape(startAngle: startAngle, endAngle: startAngle + (endAngle - startAngle) * progress)
-                        .stroke(
-                            AngularGradient(
-                                stops: [
-                                    .init(color: accentColor, location: 0.0),
-                                    .init(color: gaugeColor, location: 1.0)
-                                ],
-                                center: .center,
-                                startAngle: .degrees(startAngle),
-                                endAngle: .degrees(startAngle + (endAngle - startAngle) * progress)
-                            ),
-                            style: StrokeStyle(lineWidth: lwScaled, lineCap: .round)
-                        )
+                ArcShape(startAngle: startAngle, endAngle: startAngle + (endAngle - startAngle) * progress)
+                    .stroke(
+                        AngularGradient(
+                            stops: [
+                                .init(color: accentColor, location: 0.0),
+                                .init(color: gaugeColor, location: 1.0)
+                            ],
+                            center: .center,
+                            startAngle: .degrees(startAngle),
+                            endAngle: .degrees(startAngle + (endAngle - startAngle) * progress)
+                        ),
+                        style: StrokeStyle(lineWidth: lwScaled, lineCap: .round)
+                    )
 
-                    VStack(spacing: 2) {
-                        Text(displayValue)
-                            .font(.system(size: valueFontSize, weight: .bold, design: design))
-                            .foregroundStyle(Theme.text1(ts))
-                            .contentTransition(.numericText())
-                            .minimumScaleFactor(0.5)
-                        if !unit.isEmpty && !isCompact {
-                            Text(unit)
-                                .font(.system(size: unitFontSize, weight: .semibold, design: design))
-                                .foregroundStyle(Theme.text2(ts))
-                                .textCase(.uppercase)
-                                .minimumScaleFactor(0.4)
-                                .lineLimit(1)
-                        }
+                VStack(spacing: 2) {
+                    Text(displayValue)
+                        .font(.system(size: valueFontSize, weight: .bold, design: design))
+                        .foregroundStyle(Theme.text1(ts))
+                        .contentTransition(.numericText())
+                        .minimumScaleFactor(0.5)
+                    if !unit.isEmpty && !isCompact {
+                        Text(unit)
+                            .font(.system(size: unitFontSize, weight: .semibold, design: design))
+                            .foregroundStyle(Theme.text2(ts))
+                            .textCase(.uppercase)
+                            .minimumScaleFactor(0.4)
+                            .lineLimit(1)
+                    }
+                    if showLabel {
+                        Text(label)
+                            .font(.system(size: labelFontSize, weight: .bold, design: design))
+                            .foregroundStyle(Theme.text3(ts))
+                            .textCase(.uppercase)
+                            .lineLimit(1)
                     }
                 }
-                .aspectRatio(1, contentMode: .fit)
-
-                if showLabel {
-                    Text(label)
-                        .font(.system(size: labelFontSize, weight: .bold, design: design))
-                        .foregroundStyle(Theme.text2(ts))
-                        .textCase(.uppercase)
-                        .lineLimit(1)
-                }
             }
+            .aspectRatio(1, contentMode: .fit)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }

--- a/Sources/EdgeControl/UI/Components/RadialGaugeView.swift
+++ b/Sources/EdgeControl/UI/Components/RadialGaugeView.swift
@@ -72,7 +72,7 @@ struct RadialGaugeView: View {
                         .foregroundStyle(Theme.text1(ts))
                         .contentTransition(.numericText())
                         .minimumScaleFactor(0.5)
-                    if !unit.isEmpty && !isCompact {
+                    if !unit.isEmpty {
                         Text(unit)
                             .font(.system(size: unitFontSize, weight: .semibold, design: design))
                             .foregroundStyle(Theme.text2(ts))

--- a/Sources/EdgeControl/UI/Components/TouchScrollView.swift
+++ b/Sources/EdgeControl/UI/Components/TouchScrollView.swift
@@ -65,6 +65,24 @@ public struct TouchScrollView<Content: View>: View {
             .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
             .contentShape(Rectangle())
             .clipped()
+            // Trackpad / mouse-wheel scrolling alongside the touch drag.
+            .background(
+                ScrollWheelCatcher { delta in
+                    guard maxScroll > 0 else { return }
+                    fadeOutWorkItem?.cancel()
+                    if scrollbarOpacity < 1 {
+                        withAnimation(.easeOut(duration: 0.12)) { scrollbarOpacity = 1 }
+                    }
+                    let next = min(0, max(-maxScroll, offset + delta))
+                    offset = next
+                    offsetAtDragStart = next
+                    let work = DispatchWorkItem {
+                        withAnimation(.easeIn(duration: 0.45)) { scrollbarOpacity = 0 }
+                    }
+                    fadeOutWorkItem = work
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.9, execute: work)
+                }
+            )
             .gesture(
                 DragGesture(minimumDistance: 4, coordinateSpace: .local)
                     .onChanged { value in
@@ -169,5 +187,50 @@ private struct ContentHeightKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())
+    }
+}
+
+
+/// Feeds scroll-wheel / two-finger-trackpad deltas to the touch scroller.
+/// A hit-test-transparent overlay would never receive scrollWheel (delivery
+/// follows hitTest), so this installs a local event monitor instead and
+/// claims only events that land inside its own bounds in its own window.
+private struct ScrollWheelCatcher: NSViewRepresentable {
+    let onScroll: (CGFloat) -> Void
+
+    func makeNSView(context: Context) -> CatcherView {
+        let view = CatcherView()
+        view.onScroll = onScroll
+        return view
+    }
+
+    func updateNSView(_ view: CatcherView, context: Context) {
+        view.onScroll = onScroll
+    }
+
+    final class CatcherView: NSView {
+        var onScroll: ((CGFloat) -> Void)?
+        private var monitor: Any?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if window == nil {
+                if let monitor { NSEvent.removeMonitor(monitor) }
+                monitor = nil
+            } else if monitor == nil {
+                monitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
+                    guard let self, let window = self.window, event.window === window else { return event }
+                    let point = self.convert(event.locationInWindow, from: nil)
+                    guard self.bounds.contains(point) else { return event }
+                    // Trackpads report precise pixel deltas; wheels report
+                    // lines and need scaling to feel comparable.
+                    let delta = event.hasPreciseScrollingDeltas
+                        ? event.scrollingDeltaY
+                        : event.scrollingDeltaY * 12
+                    self.onScroll?(delta)
+                    return nil
+                }
+            }
+        }
     }
 }

--- a/Sources/EdgeControl/UI/Components/TouchScrollView.swift
+++ b/Sources/EdgeControl/UI/Components/TouchScrollView.swift
@@ -115,7 +115,14 @@ public struct TouchScrollView<Content: View>: View {
                     }
             )
             .onPreferenceChange(ContentHeightKey.self) { h in
-                if h > 0 { contentHeight = h }
+                if h > 0 {
+                    contentHeight = h
+                    // Content can shrink (devices disconnect, run lists
+                    // collapse): a stale offset would pin the viewport past
+                    // the new end with no gesture able to bring it back.
+                    let maxScroll = max(0, h - geo.size.height)
+                    if offset < -maxScroll { offset = -maxScroll }
+                }
             }
         }
     }

--- a/Sources/EdgeControl/UI/Components/WidgetHeader.swift
+++ b/Sources/EdgeControl/UI/Components/WidgetHeader.swift
@@ -36,13 +36,22 @@ struct RatePairView: View {
     let first: Entry
     let second: Entry
     var compact: Bool = false
+    /// One-column cells stack the groups; anything wider sits side by side.
+    var vertical: Bool = false
 
     @Environment(\.themeSettings) private var ts
 
     var body: some View {
-        HStack(spacing: 12) {
-            group(first)
-            group(second)
+        if vertical {
+            VStack(alignment: .leading, spacing: 8) {
+                group(first)
+                group(second)
+            }
+        } else {
+            HStack(spacing: 12) {
+                group(first)
+                group(second)
+            }
         }
     }
 

--- a/Sources/EdgeControl/UI/Components/WidgetHeader.swift
+++ b/Sources/EdgeControl/UI/Components/WidgetHeader.swift
@@ -56,7 +56,7 @@ struct RatePairView: View {
                     .font(Theme.label(ts))
                     .foregroundStyle(Theme.text3(ts))
             }
-            Text(entry.value)
+            Text(Self.padded(entry.value))
                 .font(Theme.value(ts))
                 .foregroundStyle(Theme.text1(ts))
                 .monospacedDigit()
@@ -64,5 +64,16 @@ struct RatePairView: View {
                 .lineLimit(1)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Live values arrive at varying widths ("3.5 KB/s" vs "216.5 KB/s"), and
+    /// letting each width pick its own scale made the type pulse with the
+    /// data. Padding every value to the formatters' widest possible output
+    /// ("1023.9 KB/s", 11 figures) with figure spaces holds the measured
+    /// width — and therefore the rendered size — perfectly still.
+    private static func padded(_ value: String) -> String {
+        let target = 11
+        guard value.count < target else { return value }
+        return value + String(repeating: "\u{2007}", count: target - value.count)
     }
 }

--- a/Sources/EdgeControl/UI/Components/WidgetHeader.swift
+++ b/Sources/EdgeControl/UI/Components/WidgetHeader.swift
@@ -19,3 +19,50 @@ struct WidgetHeader: View {
         }
     }
 }
+
+// MARK: - Rate Pair
+
+/// Two labeled rates (down/up, read/write) rendered identically wherever a
+/// widget shows them, so equal box sizes produce equal layouts across
+/// Network, Disk I/O and friends.
+struct RatePairView: View {
+    struct Entry {
+        let icon: String
+        let label: String
+        let value: String
+        let color: Color
+    }
+
+    let first: Entry
+    let second: Entry
+    var compact: Bool = false
+
+    @Environment(\.themeSettings) private var ts
+
+    var body: some View {
+        HStack(spacing: 12) {
+            group(first)
+            group(second)
+        }
+    }
+
+    private func group(_ entry: Entry) -> some View {
+        VStack(alignment: .leading, spacing: compact ? 2 : 4) {
+            HStack(spacing: 4) {
+                Image(systemName: entry.icon)
+                    .font(.system(size: (compact ? 12 : 18) * ts.fontScale))
+                    .foregroundStyle(entry.color)
+                Text(entry.label)
+                    .font(Theme.label(ts))
+                    .foregroundStyle(Theme.text3(ts))
+            }
+            Text(entry.value)
+                .font(Theme.value(ts))
+                .foregroundStyle(Theme.text1(ts))
+                .monospacedDigit()
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/Sources/EdgeControl/UI/DashboardShell.swift
+++ b/Sources/EdgeControl/UI/DashboardShell.swift
@@ -185,8 +185,12 @@ struct DashboardShell: View {
                 activeColor: accent,
                 registry: model.touchService.zoneRegistry
             ) {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    editMode.toggle()
+                // The zone registry runs actions on the main actor, but the
+                // closure itself is @Sendable, so hop explicitly for Swift 6.
+                Task { @MainActor in
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        editMode.toggle()
+                    }
                 }
             }
             .overlay {

--- a/Sources/EdgeControl/UI/DashboardShell.swift
+++ b/Sources/EdgeControl/UI/DashboardShell.swift
@@ -81,12 +81,10 @@ struct DashboardShell: View {
                         editMode ? nil : DragGesture(minimumDistance: 60)
                             .onEnded { value in
                                 guard abs(value.translation.width) > abs(value.translation.height) else { return }
-                                withAnimation {
-                                    if value.translation.width < 0 && layoutEngine.currentPageIndex < pages.count - 1 {
-                                        layoutEngine.currentPageIndex += 1
-                                    } else if value.translation.width > 0 && layoutEngine.currentPageIndex > 0 {
-                                        layoutEngine.currentPageIndex -= 1
-                                    }
+                                if value.translation.width < 0 {
+                                    layoutEngine.navigate(to: layoutEngine.currentPageIndex + 1)
+                                } else if value.translation.width > 0 {
+                                    layoutEngine.navigate(to: layoutEngine.currentPageIndex - 1)
                                 }
                             }
                     )
@@ -136,9 +134,7 @@ struct DashboardShell: View {
             let clamped = min(max(newPage, 0), layoutEngine.pageCount - 1)
             if model.currentPage != clamped { model.currentPage = clamped }
             if layoutEngine.currentPageIndex != clamped {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    layoutEngine.currentPageIndex = clamped
-                }
+                layoutEngine.navigate(to: clamped)
             }
         }
         // UI swipe → layoutEngine.currentPageIndex → sync back to model
@@ -175,7 +171,7 @@ struct DashboardShell: View {
                     )
                     .animation(.easeInOut(duration: 0.2), value: layoutEngine.currentPageIndex)
                     .onTapGesture {
-                        withAnimation { layoutEngine.currentPageIndex = index }
+                        layoutEngine.navigate(to: index)
                     }
             }
         }
@@ -206,9 +202,7 @@ struct DashboardShell: View {
                             if let idx = layoutEngine.sortedPages.firstIndex(where: {
                                 !layoutEngine.overlappingInstanceIds(pageId: $0.id).isEmpty
                             }) {
-                                withAnimation(.easeInOut(duration: 0.3)) {
-                                    layoutEngine.currentPageIndex = idx
-                                }
+                                layoutEngine.navigate(to: idx)
                             }
                             return
                         }

--- a/Sources/EdgeControl/UI/DashboardShell.swift
+++ b/Sources/EdgeControl/UI/DashboardShell.swift
@@ -140,7 +140,9 @@ struct DashboardShell: View {
             WindowPlacement.configure(
                 window,
                 display: model.selectedDisplay,
-                kioskMode: layoutEngine.document.globalSettings.kioskMode
+                kioskMode: layoutEngine.document.globalSettings.kioskMode,
+                strictMonitorAffinity: layoutEngine.document.globalSettings.strictMonitorAffinity,
+                allowSystemPanels: layoutEngine.document.globalSettings.allowSystemPanels
             )
         })
         .onAppear {

--- a/Sources/EdgeControl/UI/DashboardShell.swift
+++ b/Sources/EdgeControl/UI/DashboardShell.swift
@@ -149,6 +149,14 @@ struct DashboardShell: View {
             let needed = registry.requiredServices(for: layoutEngine.document)
             model.updateActiveServices(neededServices: needed)
         }
+        // The engine owns the edit session (the widget catalog can start one
+        // by parking a widget on a full page); the local flag just mirrors it
+        // for gesture gating and overlays.
+        .onChange(of: layoutEngine.isEditing) { _, editing in
+            withAnimation(.easeInOut(duration: 0.2)) {
+                editMode = editing
+            }
+        }
     }
 
     // MARK: - Page Indicator
@@ -188,8 +196,23 @@ struct DashboardShell: View {
                 // The zone registry runs actions on the main actor, but the
                 // closure itself is @Sendable, so hop explicitly for Swift 6.
                 Task { @MainActor in
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        editMode.toggle()
+                    if layoutEngine.isEditing {
+                        // Staged overlaps cannot be saved: keep the session
+                        // open and bring the first offending page into view.
+                        if layoutEngine.hasOverlaps {
+                            if let idx = layoutEngine.sortedPages.firstIndex(where: {
+                                !layoutEngine.overlappingInstanceIds(pageId: $0.id).isEmpty
+                            }) {
+                                withAnimation(.easeInOut(duration: 0.3)) {
+                                    layoutEngine.currentPageIndex = idx
+                                }
+                            }
+                            return
+                        }
+                        layoutEngine.isEditing = false
+                        layoutEngine.save()
+                    } else {
+                        layoutEngine.isEditing = true
                     }
                 }
             }

--- a/Sources/EdgeControl/UI/DashboardShell.swift
+++ b/Sources/EdgeControl/UI/DashboardShell.swift
@@ -62,9 +62,12 @@ struct DashboardShell: View {
                                     layoutEngine: layoutEngine
                                 )
                                 .padding(8)
+                                // Forward slides in from the trailing edge;
+                                // backward reverses both edges so pages appear
+                                // to travel the way you swiped.
                                 .transition(.asymmetric(
-                                    insertion: .move(edge: .trailing),
-                                    removal: .move(edge: .leading)
+                                    insertion: .move(edge: layoutEngine.navigatingForward ? .trailing : .leading),
+                                    removal: .move(edge: layoutEngine.navigatingForward ? .leading : .trailing)
                                 ))
                             }
                         }

--- a/Sources/EdgeControl/UI/DashboardShell.swift
+++ b/Sources/EdgeControl/UI/DashboardShell.swift
@@ -8,6 +8,9 @@ struct DashboardShell: View {
     @EnvironmentObject private var registry: WidgetRegistry
     @EnvironmentObject private var history: MetricsHistory
     @State private var editMode = false
+    // Live paging: finger travel applied on top of the index offset.
+    @State private var pageDragOffset: CGFloat = 0
+    @State private var lastLiveDX: CGFloat = 0
 
     private var accent: Color {
         Theme.accent(layoutEngine.document.globalSettings.theme)
@@ -50,45 +53,61 @@ struct DashboardShell: View {
                     // Current page content
                     let pages = layoutEngine.sortedPages
 
-                    ZStack {
+                    // iPhone-style paging: every page sits in one wide
+                    // HStack offset by the current index plus the live finger
+                    // travel, so the content is attached to the finger and the
+                    // settle direction is pure geometry. Only the current page
+                    // and its neighbors render real content.
+                    let pageWidth = geo.size.width
+                    HStack(spacing: 0) {
                         ForEach(Array(pages.enumerated()), id: \.element.id) { index, page in
-                            if index == layoutEngine.currentPageIndex {
-                                GridPageView(
-                                    page: page,
-                                    registry: registry,
-                                    gridColumns: grid.columns,
-                                    gridRows: grid.rows,
-                                    editMode: $editMode,
-                                    layoutEngine: layoutEngine
-                                )
-                                .padding(8)
-                                // Forward slides in from the trailing edge;
-                                // backward reverses both edges so pages appear
-                                // to travel the way you swiped.
-                                .transition(.asymmetric(
-                                    insertion: .move(edge: layoutEngine.navigatingForward ? .trailing : .leading),
-                                    removal: .move(edge: layoutEngine.navigatingForward ? .leading : .trailing)
-                                ))
+                            Group {
+                                if abs(index - layoutEngine.currentPageIndex) <= 1 {
+                                    GridPageView(
+                                        page: page,
+                                        registry: registry,
+                                        gridColumns: grid.columns,
+                                        gridRows: grid.rows,
+                                        editMode: $editMode,
+                                        layoutEngine: layoutEngine
+                                    )
+                                    .padding(8)
+                                } else {
+                                    Color.clear
+                                }
                             }
+                            .frame(width: pageWidth, height: geo.size.height)
                         }
                     }
+                    .frame(width: pageWidth, height: geo.size.height, alignment: .leading)
+                    .offset(x: -CGFloat(layoutEngine.currentPageIndex) * pageWidth + pageDragOffset)
                     // Without this the swipe only starts on a widget card: the
                     // gaps between cards draw nothing, and SwiftUI delivers
                     // gestures only where content exists. Same reason
                     // TouchTappable, TouchButton and TouchScrollView all set it.
                     .contentShape(Rectangle())
                     .gesture(
-                        editMode ? nil : DragGesture(minimumDistance: 60)
-                            .onEnded { value in
+                        editMode ? nil : DragGesture(minimumDistance: 10)
+                            .onChanged { value in
                                 guard abs(value.translation.width) > abs(value.translation.height) else { return }
-                                if value.translation.width < 0 {
-                                    layoutEngine.navigate(to: layoutEngine.currentPageIndex + 1)
-                                } else if value.translation.width > 0 {
-                                    layoutEngine.navigate(to: layoutEngine.currentPageIndex - 1)
-                                }
+                                pageDragOffset = rubberBand(value.translation.width, pageCount: pages.count)
+                            }
+                            .onEnded { value in
+                                settlePages(dx: value.translation.width, pageCount: pages.count)
                             }
                     )
-                    .animation(.easeInOut(duration: 0.3), value: layoutEngine.currentPageIndex)
+                    // Hardware finger: track while down, settle on release.
+                    .onReceive(model.touchService.$liveSwipeDX) { dx in
+                        guard !editMode else { return }
+                        if let dx {
+                            lastLiveDX = dx
+                            pageDragOffset = rubberBand(dx, pageCount: pages.count)
+                        } else if pageDragOffset != 0 {
+                            let released = lastLiveDX
+                            lastLiveDX = 0
+                            settlePages(dx: released, pageCount: pages.count)
+                        }
+                    }
 
                     // Page indicator dots
                     pageIndicator(pageCount: pages.count)
@@ -134,7 +153,9 @@ struct DashboardShell: View {
             let clamped = min(max(newPage, 0), layoutEngine.pageCount - 1)
             if model.currentPage != clamped { model.currentPage = clamped }
             if layoutEngine.currentPageIndex != clamped {
-                layoutEngine.navigate(to: clamped)
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                    layoutEngine.navigate(to: clamped)
+                }
             }
         }
         // UI swipe → layoutEngine.currentPageIndex → sync back to model
@@ -158,6 +179,28 @@ struct DashboardShell: View {
         }
     }
 
+    // MARK: - Paging
+
+    /// Dragging past the first/last page moves at one-third rate, iPhone-style.
+    private func rubberBand(_ dx: CGFloat, pageCount: Int) -> CGFloat {
+        let index = layoutEngine.currentPageIndex
+        let overshooting = (index == 0 && dx > 0) || (index >= pageCount - 1 && dx < 0)
+        return overshooting ? dx / 3 : dx
+    }
+
+    /// One decision point for both input paths: past the threshold pages,
+    /// short of it springs back — a single animated transaction either way.
+    private func settlePages(dx: CGFloat, pageCount: Int) {
+        let index = layoutEngine.currentPageIndex
+        var target = index
+        if dx < -100, index < pageCount - 1 { target = index + 1 }
+        if dx > 100, index > 0 { target = index - 1 }
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+            layoutEngine.navigate(to: target)
+            pageDragOffset = 0
+        }
+    }
+
     // MARK: - Page Indicator
 
     private func pageIndicator(pageCount: Int) -> some View {
@@ -171,7 +214,9 @@ struct DashboardShell: View {
                     )
                     .animation(.easeInOut(duration: 0.2), value: layoutEngine.currentPageIndex)
                     .onTapGesture {
-                        layoutEngine.navigate(to: index)
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                            layoutEngine.navigate(to: index)
+                        }
                     }
             }
         }

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -175,10 +175,51 @@ struct GridPageView: View {
                                         )
                                         .allowsHitTesting(false)
 
-                                    // Remove button (top-right)
+                                    // Remove button (top-right); the
+                                    // selected widget also gets stacking
+                                    // controls so overlapped widgets can be
+                                    // pulled out from under one another.
                                     VStack {
                                         HStack {
                                             Spacer()
+                                            if isSelected {
+                                                Button {
+                                                    // Deselect too: selection
+                                                    // floats the widget, which
+                                                    // would keep hiding the
+                                                    // one underneath.
+                                                    layoutEngine.reorderWidget(
+                                                        pageId: page.id,
+                                                        instanceId: placement.instanceId,
+                                                        toFront: false
+                                                    )
+                                                    selectedInstanceId = nil
+                                                } label: {
+                                                    Image(systemName: "square.3.layers.3d.bottom.filled")
+                                                        .font(.system(size: 15))
+                                                        .foregroundStyle(.white.opacity(0.9))
+                                                        .background(Circle().fill(Color.black.opacity(0.6)).padding(-4))
+                                                }
+                                                .buttonStyle(.plain)
+                                                .help("Send to back")
+                                                .padding(.trailing, 6)
+
+                                                Button {
+                                                    layoutEngine.reorderWidget(
+                                                        pageId: page.id,
+                                                        instanceId: placement.instanceId,
+                                                        toFront: true
+                                                    )
+                                                } label: {
+                                                    Image(systemName: "square.3.layers.3d.top.filled")
+                                                        .font(.system(size: 15))
+                                                        .foregroundStyle(.white.opacity(0.9))
+                                                        .background(Circle().fill(Color.black.opacity(0.6)).padding(-4))
+                                                }
+                                                .buttonStyle(.plain)
+                                                .help("Bring to front")
+                                                .padding(.trailing, 6)
+                                            }
                                             Button {
                                                 layoutEngine.removeWidget(pageId: page.id, instanceId: placement.instanceId)
                                             } label: {

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -115,9 +115,18 @@ struct GridPageView: View {
                         let h = CGFloat(placement.height) * cellH
 
                         ZStack {
+                            // Placement identity rides along in the config so
+                            // self-editing widgets (sticky note) can write
+                            // their state back through the layout engine.
+                            let cfg: WidgetConfig = {
+                                var c = placement.config
+                                c["_pageId"] = .string(page.id)
+                                c["_instanceId"] = .string(placement.instanceId)
+                                return c
+                            }()
                             AnyView(widget.body(
                                 size: WidgetSize(width: placement.width, height: placement.height),
-                                config: placement.config
+                                config: cfg
                             ))
                             .padding(CGFloat(layoutEngine.document.globalSettings.theme.widgetGap))
                         }

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -174,11 +174,12 @@ struct GridPageView: View {
                                 }
                             }
                         }
-                        // Mouse-only affordance: a gear fades in at the top
-                        // right on hover and deep-links to this widget's
-                        // settings. Hidden entirely (not just transparent)
-                        // when unhovered so it can't swallow touches.
-                        .overlay(alignment: .topTrailing) {
+                        // Mouse-only affordance: a gear fades in at the
+                        // bottom right on hover and deep-links to this
+                        // widget's settings. Hidden entirely (not just
+                        // transparent) when unhovered so it can't swallow
+                        // touches.
+                        .overlay(alignment: .bottomTrailing) {
                             if !editMode, hoveredInstanceId == placement.instanceId {
                                 Button {
                                     layoutEngine.settingsFocus = LayoutEngine.SettingsFocus(

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -186,7 +186,10 @@ struct GridPageView: View {
                                 if editMode {
                                     selectedInstanceId = placement.instanceId
                                 } else {
-                                    WidgetLaunch.launch(launchTarget(for: placement))
+                                    WidgetLaunch.launch(
+                                        launchTarget(for: placement),
+                                        tab: placement.config.string(WidgetLaunch.tabConfigKey, default: "CPU")
+                                    )
                                 }
                             }
                         }

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -135,11 +135,25 @@ struct GridPageView: View {
                                 c["_instanceId"] = .string(placement.instanceId)
                                 return c
                             }()
-                            AnyView(widget.body(
-                                size: WidgetSize(width: placement.width, height: placement.height),
-                                config: cfg
-                            ))
-                            .padding(CGFloat(layoutEngine.document.globalSettings.theme.widgetGap))
+                            // Equatable wrapper: drag state changes re-render
+                            // this page body ~60x/s, and rebuilding every
+                            // widget's view tree each tick is what made
+                            // dragging janky. The wrapper skips a widget's
+                            // body unless its own inputs changed, so a drag
+                            // only updates cheap transforms.
+                            WidgetContentView(
+                                registry: registry,
+                                widgetId: placement.widgetId,
+                                width: placement.width,
+                                height: placement.height,
+                                config: cfg,
+                                gap: CGFloat(layoutEngine.document.globalSettings.theme.widgetGap)
+                            )
+                            .equatable()
+                            // In edit mode the widget's own controls go
+                            // inert: any point on the card drags it, and a
+                            // tap selects it instead of poking the widget.
+                            .allowsHitTesting(!editMode)
                         }
                         .frame(width: w, height: h)
                         // Compact layouts at large font scales can overflow a
@@ -424,5 +438,37 @@ struct GridPageView: View {
             }
         }
         .allowsHitTesting(false)
+    }
+}
+
+
+/// The widget's rendered body behind an explicit Equatable gate: SwiftUI
+/// skips re-evaluating it unless the placement's own inputs change, which
+/// keeps edit-mode drags from rebuilding every widget on the page per tick.
+private struct WidgetContentView: View, Equatable {
+    let registry: WidgetRegistry
+    let widgetId: String
+    let width: Int
+    let height: Int
+    let config: WidgetConfig
+    let gap: CGFloat
+
+    // The registry is a process-wide singleton, so identity of the value
+    // fields is the whole story; touching the non-Sendable registry here
+    // would also violate the nonisolated Equatable requirement.
+    nonisolated static func == (a: Self, b: Self) -> Bool {
+        a.widgetId == b.widgetId
+            && a.width == b.width && a.height == b.height
+            && a.config == b.config && a.gap == b.gap
+    }
+
+    var body: some View {
+        if let widget = registry.widget(for: widgetId) {
+            AnyView(widget.body(
+                size: WidgetSize(width: width, height: height),
+                config: config
+            ))
+            .padding(gap)
+        }
     }
 }

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -98,6 +98,9 @@ struct GridPageView: View {
                             .padding(CGFloat(layoutEngine.document.globalSettings.theme.widgetGap))
                         }
                         .frame(width: w, height: h)
+                        // Compact layouts at large font scales can overflow a
+                        // 1-row cell; never let a widget paint over neighbors.
+                        .clipped()
                         .opacity(isDragging ? 0.5 : isResizing ? 0.7 : 1)
                         .overlay {
                             if editMode {

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -13,7 +13,6 @@ struct GridPageView: View {
 
     // Drag state
     @State private var draggingInstanceId: String?
-    @State private var dragOffset: CGSize = .zero
     @State private var dragTargetCol: Int?
     @State private var dragTargetRow: Int?
     @State private var dragIsValid: Bool = false
@@ -293,7 +292,6 @@ struct GridPageView: View {
                                 }
                             }
                         }
-                        .offset(isDragging ? dragOffset : .zero)
                         .position(x: x + w / 2, y: y + h / 2)
                         .gesture(editMode ? dragGesture(placement: placement, cellW: cellW, cellH: cellH) : nil)
                         .zIndex(isDragging || isResizing ? 100 : isSelected && editMode ? 50 : 0)
@@ -348,7 +346,6 @@ struct GridPageView: View {
             .onChanged { value in
                 draggingInstanceId = placement.instanceId
                 selectedInstanceId = placement.instanceId
-                dragOffset = value.translation
 
                 // Calculate target grid cell from drag position
                 let newCol = placement.col + Int(round(value.translation.width / cellW))
@@ -386,10 +383,10 @@ struct GridPageView: View {
                     }
                 }
 
-                // Reset drag state
+                // Reset drag state (the card never moved — it dims in
+                // place and jumps to its new cell on drop)
                 withAnimation(.easeOut(duration: 0.2)) {
                     draggingInstanceId = nil
-                    dragOffset = .zero
                     dragTargetCol = nil
                     dragTargetRow = nil
                     dragIsValid = false

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -58,6 +58,7 @@ struct GridPageView: View {
                             && NSEvent.modifierFlags.contains(.command)
                         if commandHeld != held { commandHeld = held }
                     }
+                    .background(EditKeyCatcher(layoutEngine: layoutEngine))
 
                 // Drop target highlight during drag
                 if let targetCol = dragTargetCol, let targetRow = dragTargetRow,
@@ -378,7 +379,10 @@ struct GridPageView: View {
                     // Anything the drop landed on steps aside to its
                     // nearest free spot; no room means it stays staged.
                     withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
-                        layoutEngine.resolveOverlaps(pageId: page.id, keeping: placement.instanceId)
+                        layoutEngine.resolveOverlaps(
+                            pageId: page.id, keeping: placement.instanceId,
+                            minSize: { registry.widget(for: $0)?.supportedSizes.min }
+                        )
                     }
                 }
 
@@ -449,7 +453,10 @@ struct GridPageView: View {
                                         newHeight: th
                                     )
                                     withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
-                                        layoutEngine.resolveOverlaps(pageId: page.id, keeping: placement.instanceId)
+                                        layoutEngine.resolveOverlaps(
+                                            pageId: page.id, keeping: placement.instanceId,
+                                            minSize: { registry.widget(for: $0)?.supportedSizes.min }
+                                        )
                                     }
                                 }
                                 withAnimation(.easeOut(duration: 0.2)) {
@@ -518,6 +525,58 @@ private struct WidgetContentView: View, Equatable {
                 config: config
             ))
             .padding(gap)
+        }
+    }
+}
+
+
+/// Edit-session keyboard: Esc cancels back to the last saved layout,
+/// Cmd+Z / Shift+Cmd+Z step through the session's changes. A local event
+/// monitor rather than key-view plumbing, because the kiosk's SwiftUI tree
+/// never takes first responder for these. Claims events only while editing
+/// and only in its own window, before menu dispatch sees them.
+private struct EditKeyCatcher: NSViewRepresentable {
+    let layoutEngine: LayoutEngine
+
+    func makeNSView(context: Context) -> CatcherView {
+        let view = CatcherView()
+        view.engine = layoutEngine
+        return view
+    }
+
+    func updateNSView(_ view: CatcherView, context: Context) {
+        view.engine = layoutEngine
+    }
+
+    final class CatcherView: NSView {
+        weak var engine: LayoutEngine?
+        private var monitor: Any?
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            if window == nil {
+                if let monitor { NSEvent.removeMonitor(monitor) }
+                monitor = nil
+            } else if monitor == nil {
+                monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                    guard let self, let engine = self.engine, engine.isEditing,
+                          event.window === self.window else { return event }
+                    if event.keyCode == 53 { // Esc
+                        engine.cancelEditing()
+                        return nil
+                    }
+                    if event.modifierFlags.contains(.command),
+                       event.charactersIgnoringModifiers?.lowercased() == "z" {
+                        if event.modifierFlags.contains(.shift) {
+                            engine.redoLayout()
+                        } else {
+                            engine.undoLayout()
+                        }
+                        return nil
+                    }
+                    return event
+                }
+            }
         }
     }
 }

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -31,6 +31,9 @@ struct GridPageView: View {
         GeometryReader { geo in
             let cellW = geo.size.width / CGFloat(gridColumns)
             let cellH = geo.size.height / CGFloat(gridRows)
+            // Overlaps are a legal staging state while editing, marked so the
+            // user knows what still needs separating before edit mode can end.
+            let overlappedIds = editMode ? layoutEngine.overlappingInstanceIds(pageId: page.id) : []
 
             ZStack(alignment: .topLeading) {
                 // Grid lines — more visible in edit mode
@@ -39,12 +42,17 @@ struct GridPageView: View {
                 // Drop target highlight during drag
                 if let targetCol = dragTargetCol, let targetRow = dragTargetRow,
                    let dragging = page.widgets.first(where: { $0.instanceId == draggingInstanceId }) {
+                    // Green = free, orange = staged overlap, red = off-grid.
+                    let targetRect = GridRect(col: targetCol, row: targetRow, width: dragging.width, height: dragging.height)
+                    let tint: Color = !dragIsValid ? Theme.accentRed
+                        : layoutEngine.wouldOverlap(pageId: page.id, rect: targetRect, excludeInstanceId: dragging.instanceId)
+                            ? Theme.accentOrange : Theme.accentGreen
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(dragIsValid ? Theme.accentGreen.opacity(0.15) : Theme.accentRed.opacity(0.15))
+                        .fill(tint.opacity(0.15))
                         .overlay(
                             RoundedRectangle(cornerRadius: 6, style: .continuous)
                                 .strokeBorder(
-                                    dragIsValid ? Theme.accentGreen.opacity(0.5) : Theme.accentRed.opacity(0.5),
+                                    tint.opacity(0.5),
                                     style: StrokeStyle(lineWidth: 2, dash: [6, 4])
                                 )
                         )
@@ -63,12 +71,18 @@ struct GridPageView: View {
                 if let resId = resizingInstanceId,
                    let resPlacement = page.widgets.first(where: { $0.instanceId == resId }),
                    let tw = resizeTargetW, let th = resizeTargetH {
+                    // Purple = free, orange = staged overlap, red = size the
+                    // widget doesn't support (or off-grid).
+                    let resRect = GridRect(col: resPlacement.col, row: resPlacement.row, width: tw, height: th)
+                    let resTint: Color = !resizeIsValid ? Theme.accentRed
+                        : layoutEngine.wouldOverlap(pageId: page.id, rect: resRect, excludeInstanceId: resId)
+                            ? Theme.accentOrange : Theme.accentPurple
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(resizeIsValid ? Theme.accentPurple.opacity(0.12) : Theme.accentRed.opacity(0.12))
+                        .fill(resTint.opacity(0.12))
                         .overlay(
                             RoundedRectangle(cornerRadius: 6, style: .continuous)
                                 .strokeBorder(
-                                    resizeIsValid ? Theme.accentPurple.opacity(0.5) : Theme.accentRed.opacity(0.5),
+                                    resTint.opacity(0.5),
                                     style: StrokeStyle(lineWidth: 2, dash: [6, 4])
                                 )
                         )
@@ -105,9 +119,14 @@ struct GridPageView: View {
                         .overlay {
                             if editMode {
                                 ZStack {
-                                    // Edit mode border
+                                    // Edit mode border; overlapped widgets are
+                                    // flagged orange until separated.
+                                    let isOverlapped = overlappedIds.contains(placement.instanceId)
                                     RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                        .strokeBorder(accent.opacity(0.4), lineWidth: 1.5)
+                                        .strokeBorder(
+                                            isOverlapped ? Theme.accentOrange.opacity(0.9) : accent.opacity(0.4),
+                                            lineWidth: isOverlapped ? 2.5 : 1.5
+                                        )
                                         .allowsHitTesting(false)
 
                                     // Remove button (top-right)
@@ -143,11 +162,15 @@ struct GridPageView: View {
                 // Edit mode label
                 if editMode {
                     HStack(spacing: 6) {
-                        Circle().fill(accent).frame(width: 8, height: 8)
+                        Circle()
+                            .fill(overlappedIds.isEmpty ? accent : Theme.accentOrange)
+                            .frame(width: 8, height: 8)
                         Text("EDIT MODE")
                             .font(.system(size: 11, weight: .heavy, design: .rounded))
-                            .foregroundStyle(accent)
-                        Text("— drag widgets to reposition")
+                            .foregroundStyle(overlappedIds.isEmpty ? accent : Theme.accentOrange)
+                        Text(overlappedIds.isEmpty
+                            ? "— drag widgets to reposition"
+                            : "— separate overlapping widgets to finish")
                             .font(.system(size: 11, weight: .medium, design: .rounded))
                             .foregroundStyle(Theme.textTertiary)
                     }

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -11,11 +11,11 @@ struct GridPageView: View {
     @ObservedObject var layoutEngine: LayoutEngine
     @EnvironmentObject private var model: AppModel
 
-    // Drag state
+    // Drag state. Which widget is being dragged/resized is page state (it
+    // changes once per gesture); where it would land lives in `targets`,
+    // which only the highlight views observe — see EditTargets.
     @State private var draggingInstanceId: String?
-    @State private var dragTargetCol: Int?
-    @State private var dragTargetRow: Int?
-    @State private var dragIsValid: Bool = false
+    @State private var targets = EditTargets()
 
     private var accent: Color {
         Theme.accent(layoutEngine.document.globalSettings.theme)
@@ -33,9 +33,6 @@ struct GridPageView: View {
 
     // Resize state
     @State private var resizingInstanceId: String?
-    @State private var resizeTargetW: Int?
-    @State private var resizeTargetH: Int?
-    @State private var resizeIsValid: Bool = false
 
     var body: some View {
         GeometryReader { geo in
@@ -59,59 +56,20 @@ struct GridPageView: View {
                     }
                     .background(EditKeyCatcher(layoutEngine: layoutEngine))
 
-                // Drop target highlight during drag
-                if let targetCol = dragTargetCol, let targetRow = dragTargetRow,
-                   let dragging = page.widgets.first(where: { $0.instanceId == draggingInstanceId }) {
-                    // Green = free, orange = staged overlap, red = off-grid.
-                    let targetRect = GridRect(col: targetCol, row: targetRow, width: dragging.width, height: dragging.height)
-                    let tint: Color = !dragIsValid ? Theme.accentRed
-                        : layoutEngine.wouldOverlap(pageId: page.id, rect: targetRect, excludeInstanceId: dragging.instanceId)
-                            ? Theme.accentOrange : Theme.accentGreen
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(tint.opacity(0.15))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .strokeBorder(
-                                    tint.opacity(0.5),
-                                    style: StrokeStyle(lineWidth: 2, dash: [6, 4])
-                                )
-                        )
-                        .frame(
-                            width: CGFloat(dragging.width) * cellW,
-                            height: CGFloat(dragging.height) * cellH
-                        )
-                        .position(
-                            x: CGFloat(targetCol) * cellW + CGFloat(dragging.width) * cellW / 2,
-                            y: CGFloat(targetRow) * cellH + CGFloat(dragging.height) * cellH / 2
-                        )
-                        .allowsHitTesting(false)
+                // Drop / resize target highlights. These are the only views
+                // that observe the live gesture targets, so a drag tick
+                // re-renders a dashed rectangle and nothing else on the page.
+                if let dragging = page.widgets.first(where: { $0.instanceId == draggingInstanceId }) {
+                    TargetHighlight(
+                        targets: targets, kind: .drag, placement: dragging,
+                        pageId: page.id, layoutEngine: layoutEngine, cellW: cellW, cellH: cellH
+                    )
                 }
-
-                // Resize target highlight
-                if let resId = resizingInstanceId,
-                   let resPlacement = page.widgets.first(where: { $0.instanceId == resId }),
-                   let tw = resizeTargetW, let th = resizeTargetH {
-                    // Purple = free, orange = staged overlap, red = size the
-                    // widget doesn't support (or off-grid).
-                    let resRect = GridRect(col: resPlacement.col, row: resPlacement.row, width: tw, height: th)
-                    let resTint: Color = !resizeIsValid ? Theme.accentRed
-                        : layoutEngine.wouldOverlap(pageId: page.id, rect: resRect, excludeInstanceId: resId)
-                            ? Theme.accentOrange : Theme.accentPurple
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(resTint.opacity(0.12))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .strokeBorder(
-                                    resTint.opacity(0.5),
-                                    style: StrokeStyle(lineWidth: 2, dash: [6, 4])
-                                )
-                        )
-                        .frame(width: CGFloat(tw) * cellW, height: CGFloat(th) * cellH)
-                        .position(
-                            x: CGFloat(resPlacement.col) * cellW + CGFloat(tw) * cellW / 2,
-                            y: CGFloat(resPlacement.row) * cellH + CGFloat(th) * cellH / 2
-                        )
-                        .allowsHitTesting(false)
+                if let resizing = page.widgets.first(where: { $0.instanceId == resizingInstanceId }) {
+                    TargetHighlight(
+                        targets: targets, kind: .resize, placement: resizing,
+                        pageId: page.id, layoutEngine: layoutEngine, cellW: cellW, cellH: cellH
+                    )
                 }
 
                 // Placed widgets
@@ -261,7 +219,10 @@ struct GridPageView: View {
                             }
                         }
                         .onHover { inside in
-                            if inside {
+                            // Hover only feeds the gear, which edit mode
+                            // hides; tracking it there would re-render the
+                            // page every time a drag crosses a card.
+                            if inside, !editMode {
                                 hoveredInstanceId = placement.instanceId
                             } else if hoveredInstanceId == placement.instanceId {
                                 hoveredInstanceId = nil
@@ -344,8 +305,10 @@ struct GridPageView: View {
     private func dragGesture(placement: WidgetPlacement, cellW: CGFloat, cellH: CGFloat) -> some Gesture {
         DragGesture()
             .onChanged { value in
-                draggingInstanceId = placement.instanceId
-                selectedInstanceId = placement.instanceId
+                // Page state changes once, on the first tick; the equality
+                // guards keep later ticks from re-rendering the page.
+                if draggingInstanceId != placement.instanceId { draggingInstanceId = placement.instanceId }
+                if selectedInstanceId != placement.instanceId { selectedInstanceId = placement.instanceId }
 
                 // Calculate target grid cell from drag position
                 let newCol = placement.col + Int(round(value.translation.width / cellW))
@@ -353,25 +316,27 @@ struct GridPageView: View {
                 let clampedCol = max(0, min(newCol, gridColumns - placement.width))
                 let clampedRow = max(0, min(newRow, gridRows - placement.height))
 
-                dragTargetCol = clampedCol
-                dragTargetRow = clampedRow
-                dragIsValid = layoutEngine.isValidPlacement(
-                    pageId: page.id,
-                    col: clampedCol,
-                    row: clampedRow,
-                    width: placement.width,
-                    height: placement.height,
-                    excludeInstanceId: placement.instanceId
-                )
+                targets.setDrag(EditTargets.Target(
+                    col: clampedCol, row: clampedRow,
+                    width: placement.width, height: placement.height,
+                    isValid: layoutEngine.isValidPlacement(
+                        pageId: page.id,
+                        col: clampedCol,
+                        row: clampedRow,
+                        width: placement.width,
+                        height: placement.height,
+                        excludeInstanceId: placement.instanceId
+                    )
+                ))
             }
             .onEnded { value in
                 // Apply move if valid
-                if dragIsValid, let col = dragTargetCol, let row = dragTargetRow {
+                if let target = targets.drag, target.isValid {
                     layoutEngine.moveWidget(
                         pageId: page.id,
                         instanceId: placement.instanceId,
-                        toCol: col,
-                        toRow: row
+                        toCol: target.col,
+                        toRow: target.row
                     )
                     // Anything the drop landed on steps aside to its
                     // nearest free spot; no room means it stays staged.
@@ -387,9 +352,7 @@ struct GridPageView: View {
                 // place and jumps to its new cell on drop)
                 withAnimation(.easeOut(duration: 0.2)) {
                     draggingInstanceId = nil
-                    dragTargetCol = nil
-                    dragTargetRow = nil
-                    dragIsValid = false
+                    targets.setDrag(nil)
                 }
             }
     }
@@ -414,7 +377,7 @@ struct GridPageView: View {
                     .gesture(
                         DragGesture()
                             .onChanged { value in
-                                resizingInstanceId = placement.instanceId
+                                if resizingInstanceId != placement.instanceId { resizingInstanceId = placement.instanceId }
                                 let deltaW = Int(round(value.translation.width / cellW))
                                 let deltaH = Int(round(value.translation.height / cellH))
                                 let newW = max(1, placement.width + deltaW)
@@ -422,10 +385,9 @@ struct GridPageView: View {
                                 let clampedW = min(newW, gridColumns - placement.col)
                                 let clampedH = min(newH, gridRows - placement.row)
 
-                                resizeTargetW = clampedW
-                                resizeTargetH = clampedH
-
-                                // Check if widget supports this size
+                                // Valid = a size the widget supports that
+                                // also stays on the grid.
+                                var isValid = false
                                 if let meta = registry.metadata(for: placement.widgetId) {
                                     let sizeOk = meta.supportedSizes.contains(WidgetSize(width: clampedW, height: clampedH))
                                     let noCollision = layoutEngine.isValidPlacement(
@@ -436,18 +398,20 @@ struct GridPageView: View {
                                         height: clampedH,
                                         excludeInstanceId: placement.instanceId
                                     )
-                                    resizeIsValid = sizeOk && noCollision
-                                } else {
-                                    resizeIsValid = false
+                                    isValid = sizeOk && noCollision
                                 }
+                                targets.setResize(EditTargets.Target(
+                                    col: placement.col, row: placement.row,
+                                    width: clampedW, height: clampedH, isValid: isValid
+                                ))
                             }
                             .onEnded { _ in
-                                if resizeIsValid, let tw = resizeTargetW, let th = resizeTargetH {
+                                if let target = targets.resize, target.isValid {
                                     layoutEngine.resizeWidget(
                                         pageId: page.id,
                                         instanceId: placement.instanceId,
-                                        newWidth: tw,
-                                        newHeight: th
+                                        newWidth: target.width,
+                                        newHeight: target.height
                                     )
                                     withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
                                         layoutEngine.resolveOverlaps(
@@ -458,9 +422,7 @@ struct GridPageView: View {
                                 }
                                 withAnimation(.easeOut(duration: 0.2)) {
                                     resizingInstanceId = nil
-                                    resizeTargetW = nil
-                                    resizeTargetH = nil
-                                    resizeIsValid = false
+                                    targets.setResize(nil)
                                 }
                             }
                     )
@@ -491,6 +453,81 @@ struct GridPageView: View {
             }
         }
         .allowsHitTesting(false)
+    }
+}
+
+
+/// Where an in-flight drag or resize would land. Deliberately not @State on
+/// the page: a gesture publishes ~60 ticks a second, and each one written to
+/// page state re-evaluated the whole page body — every card's gestures,
+/// context menu and buttons included. That is merely wasteful on its own,
+/// but once any accessibility client has queried the process (window
+/// managers, screenshot tools, text-grabbers all do; the flag is sticky for
+/// the process lifetime) SwiftUI also recomputes accessibility attachments
+/// for every invalidated gesture, and a drag went from smooth to seconds
+/// behind the finger. Only `TargetHighlight` observes this object, so a
+/// tick now re-renders one dashed rectangle. Setters skip unchanged values
+/// so a finger resting inside one cell publishes nothing.
+@MainActor
+final class EditTargets: ObservableObject {
+    struct Target: Equatable {
+        var col: Int
+        var row: Int
+        var width: Int
+        var height: Int
+        var isValid: Bool
+
+        var rect: GridRect { GridRect(col: col, row: row, width: width, height: height) }
+    }
+
+    @Published private(set) var drag: Target?
+    @Published private(set) var resize: Target?
+
+    func setDrag(_ target: Target?) {
+        if drag != target { drag = target }
+    }
+
+    func setResize(_ target: Target?) {
+        if resize != target { resize = target }
+    }
+}
+
+
+/// The dashed cell outline that follows a drag or resize. Green/purple =
+/// free, orange = staged overlap, red = off-grid or an unsupported size.
+private struct TargetHighlight: View {
+    enum Kind { case drag, resize }
+
+    @ObservedObject var targets: EditTargets
+    let kind: Kind
+    let placement: WidgetPlacement
+    let pageId: String
+    let layoutEngine: LayoutEngine
+    let cellW: CGFloat
+    let cellH: CGFloat
+
+    var body: some View {
+        if let target = kind == .drag ? targets.drag : targets.resize {
+            let free: Color = kind == .drag ? Theme.accentGreen : Theme.accentPurple
+            let tint: Color = !target.isValid ? Theme.accentRed
+                : layoutEngine.wouldOverlap(pageId: pageId, rect: target.rect, excludeInstanceId: placement.instanceId)
+                    ? Theme.accentOrange : free
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(tint.opacity(kind == .drag ? 0.15 : 0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .strokeBorder(
+                            tint.opacity(0.5),
+                            style: StrokeStyle(lineWidth: 2, dash: [6, 4])
+                        )
+                )
+                .frame(width: CGFloat(target.width) * cellW, height: CGFloat(target.height) * cellH)
+                .position(
+                    x: CGFloat(target.col) * cellW + CGFloat(target.width) * cellW / 2,
+                    y: CGFloat(target.row) * cellH + CGFloat(target.height) * cellH / 2
+                )
+                .allowsHitTesting(false)
+        }
     }
 }
 

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -9,6 +9,7 @@ struct GridPageView: View {
     let gridRows: Int
     @Binding var editMode: Bool
     @ObservedObject var layoutEngine: LayoutEngine
+    @EnvironmentObject private var model: AppModel
 
     // Drag state
     @State private var draggingInstanceId: String?
@@ -165,10 +166,18 @@ struct GridPageView: View {
                         }
                         .offset(isDragging ? dragOffset : .zero)
                         .position(x: x + w / 2, y: y + h / 2)
-                        // Tap selects; selection floats the widget above any
-                        // staged overlap so ITS handles are the clickable ones.
-                        .onTapGesture {
-                            if editMode { selectedInstanceId = placement.instanceId }
+                        // Tap: in edit mode selects (selection floats the
+                        // widget above staged overlaps so its handles win);
+                        // otherwise launches the widget's configured app.
+                        // Widget-internal zones are smaller and win hit-tests.
+                        .touchTappable(id: "widget-tap-\(placement.instanceId)", registry: model.touchService.zoneRegistry) {
+                            Task { @MainActor in
+                                if editMode {
+                                    selectedInstanceId = placement.instanceId
+                                } else {
+                                    WidgetLaunch.launch(launchTarget(for: placement))
+                                }
+                            }
                         }
                         .gesture(editMode ? dragGesture(placement: placement, cellW: cellW, cellH: cellH) : nil)
                         .zIndex(isDragging || isResizing ? 100 : isSelected && editMode ? 50 : 0)
@@ -198,6 +207,13 @@ struct GridPageView: View {
                 }
             }
         }
+    }
+
+    /// The app a tap on this widget should open: explicit config first,
+    /// per-widget default second; empty means no launcher.
+    private func launchTarget(for placement: WidgetPlacement) -> String {
+        guard !WidgetLaunch.excluded.contains(placement.widgetId) else { return "" }
+        return placement.config.string(WidgetLaunch.configKey, default: WidgetLaunch.defaultApp(for: placement.widgetId))
     }
 
     // MARK: - Drag Gesture

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -164,12 +164,14 @@ struct GridPageView: View {
                                 }
                             }
                         }
-                        .offset(isDragging ? dragOffset : .zero)
-                        .position(x: x + w / 2, y: y + h / 2)
                         // Tap: in edit mode selects (selection floats the
                         // widget above staged overlaps so its handles win);
                         // otherwise launches the widget's configured app.
                         // Widget-internal zones are smaller and win hit-tests.
+                        // MUST precede .position: that wraps the card in a
+                        // page-sized container, and a contentShape added after
+                        // it would make every widget swallow the whole page's
+                        // clicks.
                         .touchTappable(id: "widget-tap-\(placement.instanceId)", registry: model.touchService.zoneRegistry) {
                             Task { @MainActor in
                                 if editMode {
@@ -179,6 +181,8 @@ struct GridPageView: View {
                                 }
                             }
                         }
+                        .offset(isDragging ? dragOffset : .zero)
+                        .position(x: x + w / 2, y: y + h / 2)
                         .gesture(editMode ? dragGesture(placement: placement, cellW: cellW, cellH: cellH) : nil)
                         .zIndex(isDragging || isResizing ? 100 : isSelected && editMode ? 50 : 0)
                     }

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -25,6 +25,7 @@ struct GridPageView: View {
     // Selection: with overlaps staged, the selected widget renders on top so
     // its resize handle and remove button are the reachable ones.
     @State private var selectedInstanceId: String?
+    @State private var hoveredInstanceId: String?
 
     // Resize state
     @State private var resizingInstanceId: String?
@@ -171,6 +172,36 @@ struct GridPageView: View {
                                     // Resize handle (bottom-right corner)
                                     resizeHandle(placement: placement, cellW: cellW, cellH: cellH)
                                 }
+                            }
+                        }
+                        // Mouse-only affordance: a gear fades in at the top
+                        // right on hover and deep-links to this widget's
+                        // settings. Hidden entirely (not just transparent)
+                        // when unhovered so it can't swallow touches.
+                        .overlay(alignment: .topTrailing) {
+                            if !editMode, hoveredInstanceId == placement.instanceId {
+                                Button {
+                                    layoutEngine.settingsFocus = LayoutEngine.SettingsFocus(
+                                        pageId: page.id, instanceId: placement.instanceId
+                                    )
+                                    SettingsWindowController.shared.show()
+                                } label: {
+                                    Image(systemName: "gearshape.fill")
+                                        .font(.system(size: 13))
+                                        .foregroundStyle(.white.opacity(0.85))
+                                        .padding(5)
+                                        .background(Circle().fill(Color.black.opacity(0.55)))
+                                }
+                                .buttonStyle(.plain)
+                                .padding(6)
+                                .transition(.opacity)
+                            }
+                        }
+                        .onHover { inside in
+                            if inside {
+                                hoveredInstanceId = placement.instanceId
+                            } else if hoveredInstanceId == placement.instanceId {
+                                hoveredInstanceId = nil
                             }
                         }
                         // Tap: in edit mode selects (selection floats the

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -21,6 +21,10 @@ struct GridPageView: View {
         Theme.accent(layoutEngine.document.globalSettings.theme)
     }
 
+    // Selection: with overlaps staged, the selected widget renders on top so
+    // its resize handle and remove button are the reachable ones.
+    @State private var selectedInstanceId: String?
+
     // Resize state
     @State private var resizingInstanceId: String?
     @State private var resizeTargetW: Int?
@@ -38,6 +42,10 @@ struct GridPageView: View {
             ZStack(alignment: .topLeading) {
                 // Grid lines — more visible in edit mode
                 gridLines(cellW: cellW, cellH: cellH, size: geo.size)
+                Color.clear.frame(width: 0, height: 0)
+                    .onChange(of: editMode) { _, editing in
+                        if !editing { selectedInstanceId = nil }
+                    }
 
                 // Drop target highlight during drag
                 if let targetCol = dragTargetCol, let targetRow = dragTargetRow,
@@ -99,6 +107,7 @@ struct GridPageView: View {
                     if let widget = registry.widget(for: placement.widgetId) {
                         let isDragging = draggingInstanceId == placement.instanceId
                         let isResizing = resizingInstanceId == placement.instanceId
+                        let isSelected = selectedInstanceId == placement.instanceId
                         let x = CGFloat(placement.col) * cellW
                         let y = CGFloat(placement.row) * cellH
                         let w = CGFloat(placement.width) * cellW
@@ -124,8 +133,10 @@ struct GridPageView: View {
                                     let isOverlapped = overlappedIds.contains(placement.instanceId)
                                     RoundedRectangle(cornerRadius: 6, style: .continuous)
                                         .strokeBorder(
-                                            isOverlapped ? Theme.accentOrange.opacity(0.9) : accent.opacity(0.4),
-                                            lineWidth: isOverlapped ? 2.5 : 1.5
+                                            isSelected ? accent
+                                                : isOverlapped ? Theme.accentOrange.opacity(0.9)
+                                                : accent.opacity(0.4),
+                                            lineWidth: isSelected ? 2.5 : isOverlapped ? 2.5 : 1.5
                                         )
                                         .allowsHitTesting(false)
 
@@ -154,8 +165,13 @@ struct GridPageView: View {
                         }
                         .offset(isDragging ? dragOffset : .zero)
                         .position(x: x + w / 2, y: y + h / 2)
+                        // Tap selects; selection floats the widget above any
+                        // staged overlap so ITS handles are the clickable ones.
+                        .onTapGesture {
+                            if editMode { selectedInstanceId = placement.instanceId }
+                        }
                         .gesture(editMode ? dragGesture(placement: placement, cellW: cellW, cellH: cellH) : nil)
-                        .zIndex(isDragging || isResizing ? 100 : 0)
+                        .zIndex(isDragging || isResizing ? 100 : isSelected && editMode ? 50 : 0)
                     }
                 }
 
@@ -190,6 +206,7 @@ struct GridPageView: View {
         DragGesture()
             .onChanged { value in
                 draggingInstanceId = placement.instanceId
+                selectedInstanceId = placement.instanceId
                 dragOffset = value.translation
 
                 // Calculate target grid cell from drag position

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -26,6 +26,11 @@ struct GridPageView: View {
     // its resize handle and remove button are the reachable ones.
     @State private var selectedInstanceId: String?
     @State private var hoveredInstanceId: String?
+    @State private var commandHeld = false
+    // Modifier changes don't arrive as key events while the kiosk window
+    // isn't key, so the gear's Cmd gate polls the hardware state instead;
+    // state only changes (and re-renders) while a widget is hovered.
+    private let modifierTick = Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()
 
     // Resize state
     @State private var resizingInstanceId: String?
@@ -47,6 +52,11 @@ struct GridPageView: View {
                 Color.clear.frame(width: 0, height: 0)
                     .onChange(of: editMode) { _, editing in
                         if !editing { selectedInstanceId = nil }
+                    }
+                    .onReceive(modifierTick) { _ in
+                        let held = hoveredInstanceId != nil
+                            && NSEvent.modifierFlags.contains(.command)
+                        if commandHeld != held { commandHeld = held }
                     }
 
                 // Drop target highlight during drag
@@ -174,18 +184,15 @@ struct GridPageView: View {
                                 }
                             }
                         }
-                        // Mouse-only affordance: a gear fades in at the
-                        // bottom right on hover and deep-links to this
-                        // widget's settings. Hidden entirely (not just
-                        // transparent) when unhovered so it can't swallow
-                        // touches.
+                        // Mouse-only affordance: while Cmd is held, a gear
+                        // fades in at the bottom right on hover and
+                        // deep-links to this widget's settings. Hidden
+                        // entirely (not just transparent) otherwise so it
+                        // can't swallow touches.
                         .overlay(alignment: .bottomTrailing) {
-                            if !editMode, hoveredInstanceId == placement.instanceId {
+                            if !editMode, commandHeld, hoveredInstanceId == placement.instanceId {
                                 Button {
-                                    layoutEngine.settingsFocus = LayoutEngine.SettingsFocus(
-                                        pageId: page.id, instanceId: placement.instanceId
-                                    )
-                                    SettingsWindowController.shared.show()
+                                    openWidgetSettings(placement)
                                 } label: {
                                     Image(systemName: "gearshape.fill")
                                         .font(.system(size: 13))
@@ -203,6 +210,11 @@ struct GridPageView: View {
                                 hoveredInstanceId = placement.instanceId
                             } else if hoveredInstanceId == placement.instanceId {
                                 hoveredInstanceId = nil
+                            }
+                        }
+                        .contextMenu {
+                            Button("Edit This Widget's Settings") {
+                                openWidgetSettings(placement)
                             }
                         }
                         // Tap: in edit mode selects (selection floats the
@@ -259,6 +271,15 @@ struct GridPageView: View {
 
     /// The app a tap on this widget should open: explicit config first,
     /// per-widget default second; empty means no launcher.
+    /// Deep link into Settings for one widget: Pages tab, its page
+    /// selected, its config row scrolled into view.
+    private func openWidgetSettings(_ placement: WidgetPlacement) {
+        layoutEngine.settingsFocus = LayoutEngine.SettingsFocus(
+            pageId: page.id, instanceId: placement.instanceId
+        )
+        SettingsWindowController.shared.show()
+    }
+
     private func launchTarget(for placement: WidgetPlacement) -> String {
         guard !WidgetLaunch.excluded.contains(placement.widgetId) else { return "" }
         return placement.config.string(WidgetLaunch.configKey, default: WidgetLaunch.defaultApp(for: placement.widgetId))

--- a/Sources/EdgeControl/UI/GridPageView.swift
+++ b/Sources/EdgeControl/UI/GridPageView.swift
@@ -375,6 +375,11 @@ struct GridPageView: View {
                         toCol: col,
                         toRow: row
                     )
+                    // Anything the drop landed on steps aside to its
+                    // nearest free spot; no room means it stays staged.
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                        layoutEngine.resolveOverlaps(pageId: page.id, keeping: placement.instanceId)
+                    }
                 }
 
                 // Reset drag state
@@ -443,6 +448,9 @@ struct GridPageView: View {
                                         newWidth: tw,
                                         newHeight: th
                                     )
+                                    withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                                        layoutEngine.resolveOverlaps(pageId: page.id, keeping: placement.instanceId)
+                                    }
                                 }
                                 withAnimation(.easeOut(duration: 0.2)) {
                                     resizingInstanceId = nil

--- a/Sources/EdgeControl/UI/Settings/CICDSettingsView.swift
+++ b/Sources/EdgeControl/UI/Settings/CICDSettingsView.swift
@@ -16,6 +16,23 @@ struct CICDSettingsView: View {
     @State private var importError: String?
 
     private var service: CICDService { model.cicdService }
+
+    /// Repositories currently contributing runs to the widget, ready to hide.
+    /// run.id is "<accountID>/<owner>/<name>/<run number>".
+    private var shownRepositories: [CIRepositoryRef] {
+        let hidden = service.settings.hiddenRepositories
+        var seen = Set<CIRepositoryRef>()
+        var result: [CIRepositoryRef] = []
+        for run in service.runs {
+            let parts = run.id.split(separator: "/")
+            guard parts.count >= 4,
+                  let accountID = UUID(uuidString: String(parts[0])),
+                  let host = store.accounts.first(where: { $0.id == accountID })?.host else { continue }
+            let ref = CIRepositoryRef(host: host, fullName: parts.dropFirst().dropLast().joined(separator: "/"))
+            if !hidden.contains(ref), seen.insert(ref).inserted { result.append(ref) }
+        }
+        return result.sorted()
+    }
     private var store: CIAccountStore { model.accountStore }
 
     private var cliAvailable: Bool {
@@ -246,6 +263,22 @@ struct CICDSettingsView: View {
                 host: $hiddenHost,
                 text: $hiddenDraft
             )
+
+            // The typed entry above requires knowing the exact owner/name;
+            // this menu offers exactly what the widget is showing right now.
+            if !shownRepositories.isEmpty {
+                Menu {
+                    ForEach(shownRepositories, id: \.self) { ref in
+                        Button(ref.displayName) {
+                            service.settings.hiddenRepositories.insert(ref)
+                        }
+                    }
+                } label: {
+                    Label("Hide a repository currently shown…", systemImage: "eye.slash")
+                        .font(Theme.label(ts))
+                }
+                .frame(maxWidth: 320)
+            }
         }
     }
 

--- a/Sources/EdgeControl/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/EdgeControl/UI/Settings/GeneralSettingsView.swift
@@ -84,6 +84,21 @@ struct GeneralSettingsView: View {
                 )
             )
 
+            // System panel coexistence
+            settingsToggle(
+                "Allow System Panels Over Dashboard",
+                subtitle: "Clipboard managers (Paste) and similar hotkey panels can appear above the dashboard; the menu bar can too",
+                icon: "rectangle.stack",
+                isOn: Binding(
+                    get: { layoutEngine.document.globalSettings.allowSystemPanels },
+                    set: { newValue in
+                        var gs = layoutEngine.document.globalSettings
+                        gs.allowSystemPanels = newValue
+                        layoutEngine.updateGlobalSettings(gs)
+                    }
+                )
+            )
+
             // Units
             HStack(spacing: 10) {
                 Image(systemName: "ruler")

--- a/Sources/EdgeControl/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/EdgeControl/UI/Settings/GeneralSettingsView.swift
@@ -211,7 +211,9 @@ struct GeneralSettingsView: View {
         let panel = NSSavePanel()
         panel.nameFieldStringValue = "EdgeControl-Layout.json"
         panel.allowedContentTypes = [.json]
-        if panel.runModal() == .OK, let url = panel.url {
+        guard let win = SettingsWindowController.shared.settingsWindow ?? NSApp.keyWindow else { return }
+        panel.beginSheetModal(for: win) { response in
+            guard response == .OK, let url = panel.url else { return }
             try? data.write(to: url, options: .atomic)
         }
     }
@@ -220,7 +222,9 @@ struct GeneralSettingsView: View {
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.json]
         panel.allowsMultipleSelection = false
-        if panel.runModal() == .OK, let url = panel.url {
+        guard let win = SettingsWindowController.shared.settingsWindow ?? NSApp.keyWindow else { return }
+        panel.beginSheetModal(for: win) { response in
+            guard response == .OK, let url = panel.url else { return }
             guard let data = try? Data(contentsOf: url) else { return }
             let store = LayoutStore()
             if let doc = store.importData(data) {

--- a/Sources/EdgeControl/UI/Settings/GeneralSettingsView.swift
+++ b/Sources/EdgeControl/UI/Settings/GeneralSettingsView.swift
@@ -207,7 +207,7 @@ struct GeneralSettingsView: View {
 
     private func exportLayout() {
         let store = LayoutStore()
-        guard let data = store.exportData() else { return }
+        guard let data = store.exportData(layoutEngine.document) else { return }
         let panel = NSSavePanel()
         panel.nameFieldStringValue = "EdgeControl-Layout.json"
         panel.allowedContentTypes = [.json]

--- a/Sources/EdgeControl/UI/Settings/GuideView.swift
+++ b/Sources/EdgeControl/UI/Settings/GuideView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// A long-form, scrollable reference for the dashboard and its widgets.
+/// Most of the sticky note's markdown-lite behavior is invisible until you
+/// know to type it, so it's written down here.
+struct GuideView: View {
+    @EnvironmentObject private var layoutEngine: LayoutEngine
+
+    private var accent: Color {
+        Theme.accent(layoutEngine.document.globalSettings.theme)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Guide")
+                .font(.system(size: 20, weight: .heavy, design: .rounded))
+                .foregroundStyle(.white)
+
+            ScrollView(.vertical, showsIndicators: true) {
+                VStack(alignment: .leading, spacing: 22) {
+                    section("Dashboard", rows: [
+                        ("Swipe left/right", "Move between pages — pages follow your finger."),
+                        ("Tap a widget", "Launches its configured app (set per widget under Pages)."),
+                        ("⌘ + hover", "A gear appears in the widget's corner; click it to jump straight to that widget's settings."),
+                        ("Right-click", "\"Edit This Widget's Settings\" jumps to the same place."),
+                    ])
+                    section("Edit Mode", rows: [
+                        ("Drag anywhere", "Widgets go inert while editing; any point on the card drags it."),
+                        ("Tap", "Selects a widget (selection floats it above overlaps)."),
+                        ("Corner handle", "Drag the bottom-right handle to resize."),
+                        ("Layer buttons", "On the selected widget: send to back / bring to front — for reaching widgets stacked on one another."),
+                        ("✕", "Removes the widget from the page."),
+                    ])
+                    section("Sticky Note — typing", rows: [
+                        ("- or *", "Space, then any character → bullet item."),
+                        ("1.", "Any number, a dot, then space → numbered item. Numbers keep themselves in order as you insert, delete and convert; a blank line starts the count fresh."),
+                        ("- [ ]", "Checkbox — converts at the closing bracket, so \"[x]\" can start one checked."),
+                        ("# ## ###", "Headings, three levels."),
+                        ("---", "Return turns it into a horizontal rule."),
+                        ("Switch type", "On an existing item, type another marker after it: \"1. \" on a bullet makes it numbered, \"[ ]\" makes it a checkbox, \"-\" or \"*\" makes it a bullet again."),
+                        ("Return", "Continues the list; on an empty item it ends the list instead."),
+                        ("Tab / ⇧Tab", "Indent / unindent the line, from anywhere in it."),
+                        ("Paste a URL", "Over selected text, that text becomes the link. On its own, you're asked for a title."),
+                        ("Return in a link", "Opens the link instead of breaking the line."),
+                    ])
+                    section("Sticky Note — shortcuts", rows: [
+                        ("⌘B / ⌘I / ⌘U", "Bold, italic, underline."),
+                        ("⌘⇧X", "Strikethrough."),
+                        ("⌘↩", "Check / uncheck the todo on the caret's line — or every checkbox line in a selection."),
+                        ("⌘= / ⌘-", "Bigger / smaller text."),
+                        ("⌘0", "Snap back to the configured font size."),
+                        ("⌘⇧0", "Body text — clears heading size, bold/italic, underline and strikethrough."),
+                        ("Click a box", "Toggles the checkbox; works by touch too."),
+                    ])
+                    section("Reminders", rows: [
+                        ("Add field", "Type and press Return to create a real reminder in the configured list."),
+                        ("\"in…\" field", "\":30\" = 30 minutes, \"2\" = 2 hours, \"2:15\" = two hours fifteen — sets the due time relative to now."),
+                        ("Due Today", "When on (and no \"in…\" is typed), new reminders come due at the configured Due Time and notify then."),
+                        ("Circle", "Tap to complete the reminder everywhere."),
+                    ])
+                    section("Widget Catalog", rows: [
+                        ("+", "Adds the widget to the current page; a full page stages it as an overlap to resolve in edit mode."),
+                        ("Eye", "Previews the widget at its minimum, default and maximum sizes."),
+                        ("Check", "Shown when placed; click removes the most recent copy. x2/x3 marks multiples."),
+                    ])
+                }
+                .padding(.bottom, 16)
+            }
+        }
+        .padding(16)
+    }
+
+    private func section(_ title: String, rows: [(String, String)]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.system(size: 15, weight: .heavy, design: .rounded))
+                .foregroundStyle(accent)
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(rows, id: \.0) { row in
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        Text(row.0)
+                            .font(.system(size: 12, weight: .bold, design: .monospaced))
+                            .foregroundStyle(.white)
+                            .frame(width: 130, alignment: .leading)
+                        Text(row.1)
+                            .font(.system(size: 12, weight: .medium, design: .rounded))
+                            .foregroundStyle(Theme.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .padding(12)
+            .background(Color.white.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        }
+    }
+}

--- a/Sources/EdgeControl/UI/Settings/GuideView.swift
+++ b/Sources/EdgeControl/UI/Settings/GuideView.swift
@@ -22,12 +22,13 @@ struct GuideView: View {
                         ("Swipe left/right", "Move between pages — pages follow your finger."),
                         ("Tap a widget", "Launches its configured app (set per widget under Pages)."),
                         ("⌘ + hover", "A gear appears in the widget's corner; click it to jump straight to that widget's settings."),
-                        ("Right-click", "\"Edit This Widget's Settings\" jumps to the same place."),
                     ])
                     section("Edit Mode", rows: [
+                        ("Right-click", "\"Edit This Widget's Settings\" jumps straight to its settings. Edit mode only — outside it, widgets keep the click."),
                         ("Drag anywhere", "Widgets go inert while editing; any point on the card drags it."),
                         ("Tap", "Selects a widget (selection floats it above overlaps)."),
                         ("Corner handle", "Drag the bottom-right handle to resize."),
+                        ("Drop on others", "Widgets you drop onto step aside to their nearest free spot; if there's no room they stay overlapped for you to separate."),
                         ("Layer buttons", "On the selected widget: send to back / bring to front — for reaching widgets stacked on one another."),
                         ("✕", "Removes the widget from the page."),
                     ])
@@ -42,14 +43,18 @@ struct GuideView: View {
                         ("Tab / ⇧Tab", "Indent / unindent the line, from anywhere in it."),
                         ("Paste a URL", "Over selected text, that text becomes the link. On its own, you're asked for a title."),
                         ("Return in a link", "Opens the link instead of breaking the line."),
+                        ("Click a link", "Opens it — a finger tap does too."),
+                        ("Settings", "Each note has its own card color, text color, opacity, font and size — via the ⌘-hover gear or the Pages tab."),
                     ])
                     section("Sticky Note — shortcuts", rows: [
                         ("⌘B / ⌘I / ⌘U", "Bold, italic, underline."),
                         ("⌘⇧X", "Strikethrough."),
-                        ("⌘↩", "Check / uncheck the todo on the caret's line — or every checkbox line in a selection."),
+                        ("⌘Return", "Check / uncheck the todo on the caret's line — or every checkbox line in a selection."),
                         ("⌘= / ⌘-", "Bigger / smaller text."),
                         ("⌘0", "Snap back to the configured font size."),
                         ("⌘⇧0", "Body text — clears heading size, bold/italic, underline and strikethrough."),
+                        ("⌘Z / ⇧⌘Z", "Undo / redo."),
+                        ("⌘A/C/V/X", "Select all, copy, paste, cut — the standard set."),
                         ("Click a box", "Toggles the checkbox; works by touch too."),
                     ])
                     section("Reminders", rows: [

--- a/Sources/EdgeControl/UI/Settings/GuideView.swift
+++ b/Sources/EdgeControl/UI/Settings/GuideView.swift
@@ -28,7 +28,9 @@ struct GuideView: View {
                         ("Drag anywhere", "Widgets go inert while editing; any point on the card drags it."),
                         ("Tap", "Selects a widget (selection floats it above overlaps)."),
                         ("Corner handle", "Drag the bottom-right handle to resize."),
-                        ("Drop on others", "Widgets you drop onto step aside to their nearest free spot; if there's no room they stay overlapped for you to separate."),
+                        ("Drop on others", "Widgets you drop onto step aside to the nearest free spot — shrinking toward their minimum size if that's what it takes. Only when nothing fits do they stay overlapped."),
+                        ("⌘Z / ⇧⌘Z", "Undo / redo layout changes within the edit session."),
+                        ("Esc", "Cancels the session — the layout snaps back to how it was when edit mode began."),
                         ("Layer buttons", "On the selected widget: send to back / bring to front — for reaching widgets stacked on one another."),
                         ("✕", "Removes the widget from the page."),
                     ])

--- a/Sources/EdgeControl/UI/Settings/PageManagerView.swift
+++ b/Sources/EdgeControl/UI/Settings/PageManagerView.swift
@@ -72,6 +72,9 @@ struct PageManagerView: View {
             }
             Button("Cancel", role: .cancel) {}
         }
+        .onReceive(layoutEngine.$settingsFocus) { focus in
+            if let focus { selectedPageId = focus.pageId }
+        }
         .onAppear {
             // Auto-select active page
             if selectedPageId == nil, let page = layoutEngine.currentPage {
@@ -209,17 +212,30 @@ struct PageManagerView: View {
                     }
                     .foregroundStyle(Theme.accentOrange)
                 }
-                ScrollView(.vertical, showsIndicators: false) {
-                    VStack(spacing: 4) {
-                        ForEach(page.widgets) { placement in
-                            widgetRow(pageId: page.id, placement: placement)
-                                .overlay(alignment: .leading) {
-                                    if overlapped.contains(placement.instanceId) {
-                                        RoundedRectangle(cornerRadius: 1.5)
-                                            .fill(Theme.accentOrange)
-                                            .frame(width: 3)
+                ScrollViewReader { proxy in
+                    ScrollView(.vertical, showsIndicators: false) {
+                        VStack(spacing: 4) {
+                            ForEach(page.widgets) { placement in
+                                widgetRow(pageId: page.id, placement: placement)
+                                    .overlay(alignment: .leading) {
+                                        if overlapped.contains(placement.instanceId) {
+                                            RoundedRectangle(cornerRadius: 1.5)
+                                                .fill(Theme.accentOrange)
+                                                .frame(width: 3)
+                                        }
                                     }
-                                }
+                                    .id(placement.instanceId)
+                            }
+                        }
+                    }
+                    // @Published replays the pending focus to new
+                    // subscribers, so this fires even when the pane is
+                    // created by the focus itself (page just selected).
+                    .onReceive(layoutEngine.$settingsFocus) { focus in
+                        guard let focus, focus.pageId == page.id else { return }
+                        layoutEngine.settingsFocus = nil
+                        DispatchQueue.main.async {
+                            withAnimation { proxy.scrollTo(focus.instanceId, anchor: .top) }
                         }
                     }
                 }

--- a/Sources/EdgeControl/UI/Settings/PageManagerView.swift
+++ b/Sources/EdgeControl/UI/Settings/PageManagerView.swift
@@ -7,6 +7,7 @@ struct PageManagerView: View {
     @State private var editingName: String = ""
     @State private var selectedPageId: String?
     @State private var showAddPage = false
+    @State private var flashedInstanceId: String?
     @State private var newPageName = ""
 
     private var accent: Color {
@@ -224,6 +225,20 @@ struct PageManagerView: View {
                                                 .frame(width: 3)
                                         }
                                     }
+                                    .overlay {
+                                        // Deep-link arrival flash: marks the
+                                        // row the widget gear jumped to.
+                                        if flashedInstanceId == placement.instanceId {
+                                            ZStack {
+                                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                                    .fill(accent.opacity(0.12))
+                                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                                    .strokeBorder(accent, lineWidth: 2)
+                                            }
+                                            .allowsHitTesting(false)
+                                            .transition(.opacity)
+                                        }
+                                    }
                                     .id(placement.instanceId)
                             }
                         }
@@ -236,6 +251,14 @@ struct PageManagerView: View {
                         layoutEngine.settingsFocus = nil
                         DispatchQueue.main.async {
                             withAnimation { proxy.scrollTo(focus.instanceId, anchor: .top) }
+                            flashedInstanceId = focus.instanceId
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
+                                withAnimation(.easeOut(duration: 0.6)) {
+                                    if flashedInstanceId == focus.instanceId {
+                                        flashedInstanceId = nil
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/Sources/EdgeControl/UI/Settings/PageManagerView.swift
+++ b/Sources/EdgeControl/UI/Settings/PageManagerView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct PageManagerView: View {
     @EnvironmentObject private var layoutEngine: LayoutEngine
     @EnvironmentObject private var registry: WidgetRegistry
+    @EnvironmentObject private var model: AppModel
     @State private var editingPageId: String?
     @State private var editingName: String = ""
     @State private var selectedPageId: String?
@@ -376,7 +377,17 @@ struct PageManagerView: View {
         // also gets the universal "Opens on Tap" launcher field.
         if let widget = registry.widget(for: placement.widgetId) {
             let schema: [ConfigSchemaEntry] = {
-                guard !WidgetLaunch.excluded.contains(widget.widgetId) else { return widget.configSchema }
+                var base = widget.configSchema
+                // Reminders: once the service has discovered the real lists,
+                // the free-text list field becomes a picker of them.
+                if widget.widgetId == "reminders", !model.remindersService.listNames.isEmpty,
+                   let idx = base.firstIndex(where: { $0.key == "list" }) {
+                    base[idx] = ConfigSchemaEntry(
+                        key: "list", label: "List", type: .picker,
+                        defaultValue: .string("default"),
+                        options: ["default"] + model.remindersService.listNames)
+                }
+                guard !WidgetLaunch.excluded.contains(widget.widgetId) else { return base }
                 var extra = [ConfigSchemaEntry(
                     key: WidgetLaunch.configKey, label: "Opens on Tap (app)",
                     type: .text,
@@ -393,7 +404,7 @@ struct PageManagerView: View {
                         defaultValue: .string("CPU"),
                         options: WidgetLaunch.activityMonitorTabs))
                 }
-                return widget.configSchema + extra
+                return base + extra
             }()
             WidgetConfigEditor(
                 schema: schema,

--- a/Sources/EdgeControl/UI/Settings/PageManagerView.swift
+++ b/Sources/EdgeControl/UI/Settings/PageManagerView.swift
@@ -172,7 +172,7 @@ struct PageManagerView: View {
                 // Navigate to this page
                 Button {
                     if let idx = layoutEngine.sortedPages.firstIndex(where: { $0.id == page.id }) {
-                        layoutEngine.currentPageIndex = idx
+                        layoutEngine.navigate(to: idx)
                     }
                 } label: {
                     HStack(spacing: 4) {
@@ -196,10 +196,30 @@ struct PageManagerView: View {
                     .frame(maxWidth: .infinity)
                 Spacer()
             } else {
+                // During an edit session the steppers and size menu can stage
+                // collisions (deliberately); this pane has no grid to show
+                // them on, so say it in words.
+                let overlapped = layoutEngine.overlappingInstanceIds(pageId: page.id)
+                if !overlapped.isEmpty {
+                    HStack(spacing: 6) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 11))
+                        Text("Overlapping widgets — separate them on the dashboard to finish editing")
+                            .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    }
+                    .foregroundStyle(Theme.accentOrange)
+                }
                 ScrollView(.vertical, showsIndicators: false) {
                     VStack(spacing: 4) {
                         ForEach(page.widgets) { placement in
                             widgetRow(pageId: page.id, placement: placement)
+                                .overlay(alignment: .leading) {
+                                    if overlapped.contains(placement.instanceId) {
+                                        RoundedRectangle(cornerRadius: 1.5)
+                                            .fill(Theme.accentOrange)
+                                            .frame(width: 3)
+                                    }
+                                }
                         }
                     }
                 }

--- a/Sources/EdgeControl/UI/Settings/PageManagerView.swift
+++ b/Sources/EdgeControl/UI/Settings/PageManagerView.swift
@@ -333,10 +333,17 @@ struct PageManagerView: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
 
-        // Widget config editor (if widget has configurable options)
-        if let widget = registry.widget(for: placement.widgetId), !widget.configSchema.isEmpty {
+        // Widget config editor. Every widget without its own tap behavior
+        // also gets the universal "Opens on Tap" launcher field.
+        if let widget = registry.widget(for: placement.widgetId) {
+            let schema = WidgetLaunch.excluded.contains(widget.widgetId)
+                ? widget.configSchema
+                : widget.configSchema + [ConfigSchemaEntry(
+                    key: WidgetLaunch.configKey, label: "Opens on Tap (app)",
+                    type: .text,
+                    defaultValue: .string(WidgetLaunch.defaultApp(for: widget.widgetId)))]
             WidgetConfigEditor(
-                schema: widget.configSchema,
+                schema: schema,
                 config: Binding(
                     get: { placement.config },
                     set: { newConfig in

--- a/Sources/EdgeControl/UI/Settings/PageManagerView.swift
+++ b/Sources/EdgeControl/UI/Settings/PageManagerView.swift
@@ -134,6 +134,15 @@ struct PageManagerView: View {
                 editingPageId = page.id
                 editingName = page.name
             }
+            let idx = layoutEngine.sortedPages.firstIndex { $0.id == page.id } ?? 0
+            Button("Move Up") {
+                layoutEngine.movePage(id: page.id, toOrder: idx - 1)
+            }
+            .disabled(idx == 0)
+            Button("Move Down") {
+                layoutEngine.movePage(id: page.id, toOrder: idx + 1)
+            }
+            .disabled(idx >= layoutEngine.pageCount - 1)
             if layoutEngine.pageCount > 1 {
                 Button("Delete", role: .destructive) {
                     layoutEngine.removePage(id: page.id)

--- a/Sources/EdgeControl/UI/Settings/PageManagerView.swift
+++ b/Sources/EdgeControl/UI/Settings/PageManagerView.swift
@@ -336,12 +336,26 @@ struct PageManagerView: View {
         // Widget config editor. Every widget without its own tap behavior
         // also gets the universal "Opens on Tap" launcher field.
         if let widget = registry.widget(for: placement.widgetId) {
-            let schema = WidgetLaunch.excluded.contains(widget.widgetId)
-                ? widget.configSchema
-                : widget.configSchema + [ConfigSchemaEntry(
+            let schema: [ConfigSchemaEntry] = {
+                guard !WidgetLaunch.excluded.contains(widget.widgetId) else { return widget.configSchema }
+                var extra = [ConfigSchemaEntry(
                     key: WidgetLaunch.configKey, label: "Opens on Tap (app)",
                     type: .text,
                     defaultValue: .string(WidgetLaunch.defaultApp(for: widget.widgetId)))]
+                // Tab choice appears only when the launch target is Activity
+                // Monitor (its tab set is fixed, indexed by SelectedTab).
+                let target = placement.config.string(
+                    WidgetLaunch.configKey,
+                    default: WidgetLaunch.defaultApp(for: widget.widgetId))
+                if WidgetLaunch.isActivityMonitor(target) {
+                    extra.append(ConfigSchemaEntry(
+                        key: WidgetLaunch.tabConfigKey, label: "Activity Monitor Tab",
+                        type: .picker,
+                        defaultValue: .string("CPU"),
+                        options: WidgetLaunch.activityMonitorTabs))
+                }
+                return widget.configSchema + extra
+            }()
             WidgetConfigEditor(
                 schema: schema,
                 config: Binding(

--- a/Sources/EdgeControl/UI/Settings/PluginManagerView.swift
+++ b/Sources/EdgeControl/UI/Settings/PluginManagerView.swift
@@ -147,7 +147,8 @@ struct PluginManagerView: View {
             panel.allowsMultipleSelection = false
             panel.canChooseDirectories = true
             panel.canChooseFiles = true
-            panel.begin { response in
+            guard let win = SettingsWindowController.shared.settingsWindow ?? NSApp.keyWindow else { return }
+            panel.beginSheetModal(for: win) { response in
                 guard response == .OK, let url = panel.url else { return }
                 Task { @MainActor [pluginManager, registry] in
                     pluginManager.installPlugin(from: url) { success in

--- a/Sources/EdgeControl/UI/Settings/SettingsView.swift
+++ b/Sources/EdgeControl/UI/Settings/SettingsView.swift
@@ -88,6 +88,9 @@ struct SettingsView: View {
             .frame(width: 140)
             .padding(14)
             .background(Color.black.opacity(0.3))
+            .onReceive(layoutEngine.$settingsFocus) { focus in
+                if focus != nil { selectedTab = .pages }
+            }
 
             // Divider
             Rectangle()

--- a/Sources/EdgeControl/UI/Settings/SettingsView.swift
+++ b/Sources/EdgeControl/UI/Settings/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 enum SettingsTab: String, CaseIterable {
     case pages = "Pages"
     case widgets = "Widgets"
+    case guide = "Guide"
     case theme = "Theme"
     case plugins = "Plugins"
     case cicd = "CI/CD"
@@ -13,6 +14,7 @@ enum SettingsTab: String, CaseIterable {
         switch self {
         case .pages: "rectangle.stack"
         case .widgets: "square.grid.2x2"
+        case .guide: "book"
         case .theme: "paintbrush"
         case .plugins: "puzzlepiece.extension"
         case .cicd: "arrow.triangle.branch"
@@ -104,6 +106,8 @@ struct SettingsView: View {
                     PageManagerView()
                 case .widgets:
                     WidgetCatalogView()
+                case .guide:
+                    GuideView()
                 case .theme:
                     ThemeSettingsView()
                 case .plugins:

--- a/Sources/EdgeControl/UI/Settings/SettingsWindowController.swift
+++ b/Sources/EdgeControl/UI/Settings/SettingsWindowController.swift
@@ -42,7 +42,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
 
         // If window exists and is still valid, just bring to front
         if let win = window {
-            win.level = NSWindow.Level(NSWindow.Level.statusBar.rawValue + 1)
+            win.level = .normal
             win.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
@@ -67,7 +67,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         win.setContentSize(NSSize(width: 700, height: 500))
         win.center()
         win.isReleasedWhenClosed = false
-        win.level = NSWindow.Level(NSWindow.Level.statusBar.rawValue + 1)
+        win.level = .normal
         win.delegate = self
         win.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)

--- a/Sources/EdgeControl/UI/Settings/SettingsWindowController.swift
+++ b/Sources/EdgeControl/UI/Settings/SettingsWindowController.swift
@@ -65,7 +65,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         let win = NSWindow(contentViewController: hosting)
         win.title = "EdgeControl Settings"
         win.styleMask = [.titled, .closable, .resizable]
-        win.setContentSize(NSSize(width: 700, height: 500))
+        win.setContentSize(NSSize(width: 1130, height: 755))
         win.center()
         win.isReleasedWhenClosed = false
         win.level = .normal

--- a/Sources/EdgeControl/UI/Settings/SettingsWindowController.swift
+++ b/Sources/EdgeControl/UI/Settings/SettingsWindowController.swift
@@ -43,6 +43,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         // If window exists and is still valid, just bring to front
         if let win = window {
             win.level = .normal
+            moveOffKioskScreen(win)
             win.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return
@@ -69,9 +70,28 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         win.isReleasedWhenClosed = false
         win.level = .normal
         win.delegate = self
+        moveOffKioskScreen(win)
         win.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
         window = win
+    }
+
+    /// At normal level this window is buried whenever it sits on the kiosk
+    /// display (the kiosk deliberately stays above the status-bar level), and
+    /// center() centers on whichever screen has focus — often the kiosk after
+    /// touch use. Keep the window on a screen where it can actually be seen.
+    private func moveOffKioskScreen(_ win: NSWindow) {
+        let kioskScreen = NSApp.windows.first { $0 is KioskWindow }?.screen
+        guard let kioskScreen,
+              win.screen == kioskScreen || win.screen == nil,
+              let target = NSScreen.screens.first(where: { $0 != kioskScreen })
+        else { return }
+        let size = win.frame.size
+        let v = target.visibleFrame
+        win.setFrameOrigin(NSPoint(
+            x: v.midX - size.width / 2,
+            y: v.midY - size.height / 2
+        ))
     }
 
     func close() {

--- a/Sources/EdgeControl/UI/Settings/SettingsWindowController.swift
+++ b/Sources/EdgeControl/UI/Settings/SettingsWindowController.swift
@@ -10,6 +10,12 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
 
     private var window: NSWindow?
 
+    /// Exposed so file panels can attach as sheets. The settings window sits
+    /// above the status-bar level; a detached NSSavePanel/NSOpenPanel orders
+    /// at the much lower modal-panel level and pops under it, while a sheet
+    /// is a child window and always renders over its parent.
+    var settingsWindow: NSWindow? { window }
+
     private override init() {
         super.init()
     }

--- a/Sources/EdgeControl/UI/Settings/WidgetCatalogView.swift
+++ b/Sources/EdgeControl/UI/Settings/WidgetCatalogView.swift
@@ -161,7 +161,16 @@ struct WidgetCatalogView: View {
             width: widget.defaultSize.width,
             height: widget.defaultSize.height
         )
-        guard let pos = positions.first else { return }
+        // A full page no longer blocks adding: park the widget at the origin
+        // as a staged overlap. Entering edit mode makes the overlap legal and
+        // visible, and the edit session cannot end until it's resolved.
+        let pos: GridCell
+        if let free = positions.first {
+            pos = free
+        } else {
+            layoutEngine.isEditing = true
+            pos = GridCell(col: 0, row: 0)
+        }
         layoutEngine.placeWidget(
             pageId: page.id,
             widgetId: widget.widgetId,

--- a/Sources/EdgeControl/UI/Settings/WidgetCatalogView.swift
+++ b/Sources/EdgeControl/UI/Settings/WidgetCatalogView.swift
@@ -236,7 +236,7 @@ private struct WidgetSizePreviewSheet: View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Image(systemName: widget.iconName)
-                Text("\(widget.displayName) — all supported sizes")
+                Text("\(widget.displayName) — min, default and max sizes")
                     .font(.system(size: 15, weight: .heavy, design: .rounded))
                 Spacer()
                 Text("Widgets without their service running show placeholder data")
@@ -249,9 +249,14 @@ private struct WidgetSizePreviewSheet: View {
 
             ScrollView(.vertical, showsIndicators: true) {
                 LazyVStack(alignment: .leading, spacing: 14) {
+                    // Extents only: the full width x height cross product
+                    // ran to dozens of near-identical tiles for wide-ranged
+                    // widgets and scrolled forever.
                     let range = widget.supportedSizes
-                    ForEach(Array(range.min.height...range.max.height), id: \.self) { h in
-                        ForEach(Array(range.min.width...range.max.width), id: \.self) { w in
+                    let widths = Array(Set([range.min.width, widget.defaultSize.width, range.max.width])).sorted()
+                    let heights = Array(Set([range.min.height, widget.defaultSize.height, range.max.height])).sorted()
+                    ForEach(heights, id: \.self) { h in
+                        ForEach(widths, id: \.self) { w in
                             // Narrow sizes get a larger scale — a 1-column
                             // preview at audit scale was an illegible sliver.
                             let s: CGFloat = w <= 3 ? 0.75 : scale

--- a/Sources/EdgeControl/UI/Settings/WidgetCatalogView.swift
+++ b/Sources/EdgeControl/UI/Settings/WidgetCatalogView.swift
@@ -105,7 +105,9 @@ struct WidgetCatalogView: View {
                     .foregroundStyle(.white)
                     .lineLimit(1)
                 Spacer()
-                if placedCount > 0 {
+                // The checkmark already says "placed"; the count badge
+                // only earns its pixels once there's more than one.
+                if placedCount > 1 {
                     Text("x\(placedCount)")
                         .font(.system(size: 10, weight: .bold, design: .rounded))
                         .foregroundStyle(Theme.accentGreen)

--- a/Sources/EdgeControl/UI/Settings/WidgetCatalogView.swift
+++ b/Sources/EdgeControl/UI/Settings/WidgetCatalogView.swift
@@ -4,6 +4,11 @@ struct WidgetCatalogView: View {
     @EnvironmentObject private var layoutEngine: LayoutEngine
     @EnvironmentObject private var registry: WidgetRegistry
     @State private var selectedCategory: WidgetCategory?
+    @State private var previewedWidget: PreviewItem?
+
+    private struct PreviewItem: Identifiable {
+        let id: String
+    }
 
     private var accent: Color {
         Theme.accent(layoutEngine.document.globalSettings.theme)
@@ -55,6 +60,11 @@ struct WidgetCatalogView: View {
             Spacer(minLength: 0)
         }
         .padding(16)
+        .sheet(item: $previewedWidget) { item in
+            if let widget = registry.widget(for: item.id) {
+                WidgetSizePreviewSheet(widget: widget) { previewedWidget = nil }
+            }
+        }
     }
 
     private func categoryChip(_ category: WidgetCategory?, label: String) -> some View {
@@ -117,20 +127,39 @@ struct WidgetCatalogView: View {
 
                 Spacer()
 
-                if isPlaced {
-                    Image(systemName: "checkmark.circle.fill")
+                // Renders the widget at every supported size — an audit
+                // surface for layout regressions.
+                Button {
+                    previewedWidget = PreviewItem(id: widget.widgetId)
+                } label: {
+                    Image(systemName: "eye.circle.fill")
                         .font(.system(size: 18))
-                        .foregroundStyle(Theme.accentGreen.opacity(0.5))
-                } else {
+                        .foregroundStyle(accent.opacity(0.8))
+                }
+                .buttonStyle(.plain)
+                .help("Preview at all supported sizes")
+
+                if isPlaced {
                     Button {
-                        addWidgetToCurrentPage(widget)
+                        removeOneFromCurrentPage(widgetId: widget.widgetId)
                     } label: {
-                        Image(systemName: "plus.circle.fill")
+                        Image(systemName: "checkmark.circle.fill")
                             .font(.system(size: 18))
                             .foregroundStyle(Theme.accentGreen)
                     }
                     .buttonStyle(.plain)
+                    .help("Remove one from this page")
                 }
+
+                Button {
+                    addWidgetToCurrentPage(widget)
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .font(.system(size: 18))
+                        .foregroundStyle(Theme.accentGreen)
+                }
+                .buttonStyle(.plain)
+                .help("Add to this page")
             }
         }
         .padding(10)
@@ -152,6 +181,13 @@ struct WidgetCatalogView: View {
     private func placedCountOnCurrentPage(widgetId: String) -> Int {
         guard let page = currentPage else { return 0 }
         return page.widgets.filter { $0.widgetId == widgetId }.count
+    }
+
+    /// The checkmark removes one instance per click, most recent first.
+    private func removeOneFromCurrentPage(widgetId: String) {
+        guard let page = currentPage,
+              let victim = page.widgets.last(where: { $0.widgetId == widgetId }) else { return }
+        layoutEngine.removeWidget(pageId: page.id, instanceId: victim.instanceId)
     }
 
     private func addWidgetToCurrentPage(_ widget: any DashboardWidget) {
@@ -180,5 +216,65 @@ struct WidgetCatalogView: View {
             height: widget.defaultSize.height,
             config: widget.defaultConfig()
         )
+    }
+}
+
+// MARK: - Size Preview
+
+/// Renders a widget at every size its range allows, at true cell geometry
+/// scaled down — the audit surface for per-size layout regressions.
+private struct WidgetSizePreviewSheet: View {
+    let widget: any DashboardWidget
+    let dismiss: () -> Void
+
+    private let cell: CGFloat = 120
+    private let scale: CGFloat = 0.45
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Image(systemName: widget.iconName)
+                Text("\(widget.displayName) — all supported sizes")
+                    .font(.system(size: 15, weight: .heavy, design: .rounded))
+                Spacer()
+                Text("Widgets without their service running show placeholder data")
+                    .font(.system(size: 10, weight: .medium, design: .rounded))
+                    .foregroundStyle(Theme.textTertiary)
+                Button("Close", action: dismiss)
+                    .keyboardShortcut(.defaultAction)
+            }
+            .foregroundStyle(.white)
+
+            ScrollView(.vertical, showsIndicators: true) {
+                LazyVStack(alignment: .leading, spacing: 14) {
+                    let range = widget.supportedSizes
+                    ForEach(Array(range.min.height...range.max.height), id: \.self) { h in
+                        ForEach(Array(range.min.width...range.max.width), id: \.self) { w in
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text("\(w)x\(h)")
+                                    .font(.system(size: 11, weight: .bold, design: .monospaced))
+                                    .foregroundStyle(Theme.textTertiary)
+                                AnyView(widget.body(
+                                    size: WidgetSize(width: w, height: h),
+                                    config: widget.defaultConfig()
+                                ))
+                                .frame(width: CGFloat(w) * cell, height: CGFloat(h) * cell)
+                                .clipped()
+                                .scaleEffect(scale, anchor: .topLeading)
+                                .frame(
+                                    width: CGFloat(w) * cell * scale,
+                                    height: CGFloat(h) * cell * scale,
+                                    alignment: .topLeading
+                                )
+                            }
+                        }
+                    }
+                }
+                .padding(.bottom, 12)
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 560, minHeight: 460)
+        .background(Theme.backgroundPrimary)
     }
 }

--- a/Sources/EdgeControl/UI/Settings/WidgetCatalogView.swift
+++ b/Sources/EdgeControl/UI/Settings/WidgetCatalogView.swift
@@ -250,6 +250,9 @@ private struct WidgetSizePreviewSheet: View {
                     let range = widget.supportedSizes
                     ForEach(Array(range.min.height...range.max.height), id: \.self) { h in
                         ForEach(Array(range.min.width...range.max.width), id: \.self) { w in
+                            // Narrow sizes get a larger scale — a 1-column
+                            // preview at audit scale was an illegible sliver.
+                            let s: CGFloat = w <= 3 ? 0.75 : scale
                             VStack(alignment: .leading, spacing: 3) {
                                 Text("\(w)x\(h)")
                                     .font(.system(size: 11, weight: .bold, design: .monospaced))
@@ -260,10 +263,10 @@ private struct WidgetSizePreviewSheet: View {
                                 ))
                                 .frame(width: CGFloat(w) * cell, height: CGFloat(h) * cell)
                                 .clipped()
-                                .scaleEffect(scale, anchor: .topLeading)
+                                .scaleEffect(s, anchor: .topLeading)
                                 .frame(
-                                    width: CGFloat(w) * cell * scale,
-                                    height: CGFloat(h) * cell * scale,
+                                    width: CGFloat(w) * cell * s,
+                                    height: CGFloat(h) * cell * s,
                                     alignment: .topLeading
                                 )
                             }

--- a/Sources/EdgeControl/UI/Settings/WidgetConfigEditor.swift
+++ b/Sources/EdgeControl/UI/Settings/WidgetConfigEditor.swift
@@ -142,6 +142,27 @@ struct WidgetConfigEditor: View {
             ))
             .textFieldStyle(.roundedBorder)
             .frame(width: 160)
+
+            if entry.key == WidgetLaunch.configKey {
+                Button("Browse…") { browseForApp(entry.key) }
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+            }
+        }
+    }
+
+    /// App picker for the launcher field, sheet-attached like every other
+    /// panel so it cannot pop under the settings window.
+    private func browseForApp(_ key: String) {
+        let panel = NSOpenPanel()
+        panel.title = "Choose Application"
+        panel.directoryURL = URL(fileURLWithPath: "/Applications", isDirectory: true)
+        panel.allowedContentTypes = [.application]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        guard let win = SettingsWindowController.shared.settingsWindow ?? NSApp.keyWindow else { return }
+        panel.beginSheetModal(for: win) { response in
+            guard response == .OK, let url = panel.url else { return }
+            config[key] = .string(url.path)
         }
     }
 }

--- a/Sources/EdgeControl/UI/Settings/WidgetConfigEditor.swift
+++ b/Sources/EdgeControl/UI/Settings/WidgetConfigEditor.swift
@@ -71,7 +71,7 @@ struct WidgetConfigEditor: View {
                 set: { config[entry.key] = .string($0) }
             )) {
                 ForEach(options, id: \.self) { option in
-                    Text(option.capitalized.replacingOccurrences(of: "Daybar", with: "Day Bar").replacingOccurrences(of: "Dotmatrix", with: "Dot Matrix"))
+                    Text(option.capitalized.replacingOccurrences(of: "Daybar", with: "Day Bar").replacingOccurrences(of: "Dotmatrix", with: "Dot Matrix").replacingOccurrences(of: "Cpu", with: "CPU"))
                         .tag(option)
                 }
             }

--- a/Sources/EdgeControl/UI/Settings/WidgetConfigEditor.swift
+++ b/Sources/EdgeControl/UI/Settings/WidgetConfigEditor.swift
@@ -14,7 +14,15 @@ struct WidgetConfigEditor: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             ForEach(schema, id: \.key) { entry in
-                configRow(entry)
+                VStack(alignment: .leading, spacing: 3) {
+                    configRow(entry)
+                    if let help = entry.help {
+                        Text(help)
+                            .font(.system(size: 11, weight: .medium, design: .rounded))
+                            .foregroundStyle(Theme.textTertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
             }
         }
     }
@@ -32,6 +40,8 @@ struct WidgetConfigEditor: View {
             sliderRow(entry)
         case .text:
             textRow(entry)
+        case .time:
+            timeRow(entry)
         case .colorPicker:
             EmptyView()
         }
@@ -148,6 +158,40 @@ struct WidgetConfigEditor: View {
                     .font(.system(size: 12, weight: .semibold, design: .rounded))
             }
         }
+    }
+
+    // MARK: - Time
+
+    /// Time-of-day picker persisting as "HH:mm" — the stored form stays a
+    /// plain string, so old configs and the text-field era round-trip.
+    private func timeRow(_ entry: ConfigSchemaEntry) -> some View {
+        let fallback: String = { if case .string(let v) = entry.defaultValue { return v }; return "18:00" }()
+        let currentValue = config.string(entry.key, default: fallback)
+
+        return HStack {
+            Text(entry.label)
+                .font(.system(size: 13, weight: .semibold, design: .rounded))
+                .foregroundStyle(Theme.textSecondary)
+            Spacer()
+            DatePicker("", selection: Binding(
+                get: { Self.date(fromHHmm: currentValue) },
+                set: { config[entry.key] = .string(Self.hhmm(from: $0)) }
+            ), displayedComponents: .hourAndMinute)
+            .datePickerStyle(.stepperField)
+            .labelsHidden()
+        }
+    }
+
+    private static func date(fromHHmm s: String) -> Date {
+        let parts = s.split(separator: ":")
+        let hour = parts.count == 2 ? Int(parts[0]) ?? 18 : 18
+        let minute = parts.count == 2 ? Int(parts[1]) ?? 0 : 0
+        return Calendar.current.date(bySettingHour: hour, minute: minute, second: 0, of: Date()) ?? Date()
+    }
+
+    private static func hhmm(from date: Date) -> String {
+        let c = Calendar.current.dateComponents([.hour, .minute], from: date)
+        return String(format: "%02d:%02d", c.hour ?? 18, c.minute ?? 0)
     }
 
     /// App picker for the launcher field, sheet-attached like every other

--- a/Sources/EdgeControl/Widgets/DevTools/CICDRunsWidget.swift
+++ b/Sources/EdgeControl/Widgets/DevTools/CICDRunsWidget.swift
@@ -190,6 +190,13 @@ private struct CICDRunsWidgetView: View {
                             .font(Theme.label(ts))
                             .foregroundStyle(Theme.text3(ts).opacity(0.6))
                     }
+                    // One commit can fan out to several workflows, and some runs
+                    // share a constant title ("pages build and deployment"), so
+                    // without the workflow name such rows are indistinguishable.
+                    Text("· \(run.workflowName)")
+                        .font(Theme.label(ts))
+                        .foregroundStyle(Theme.text3(ts).opacity(0.6))
+                        .lineLimit(1)
                 }
                 Text(run.title)
                     .font(Theme.body(ts))

--- a/Sources/EdgeControl/Widgets/DevTools/CICDRunsWidget.swift
+++ b/Sources/EdgeControl/Widgets/DevTools/CICDRunsWidget.swift
@@ -90,6 +90,41 @@ private struct CICDRunsWidgetView: View {
         )
     }
 
+    /// Latest run per (account, repository, workflow). The widget is a status
+    /// board, not an activity log: re-runs and repeat deployments (Pages runs
+    /// all share one title) collapse to the workflow's current state.
+    private func latestPerWorkflow(_ runs: [CIRun]) -> [CIRun] {
+        var latest: [String: CIRun] = [:]
+        for run in runs {
+            // run.id is "<accountID>/<repo full name>/<run number>"; dropping
+            // the run number yields a key that survives same-named repos in
+            // different orgs, which repositoryName (the short name) would not.
+            let repoKey = run.id[..<(run.id.lastIndex(of: "/") ?? run.id.endIndex)]
+            let key = "\(repoKey)|\(run.workflowName)"
+            if let existing = latest[key], existing.startedAt >= run.startedAt { continue }
+            latest[key] = run
+        }
+        return latest.values.sorted { $0.startedAt > $1.startedAt }
+    }
+
+    /// The header badge counts what the list shows: distinct workflows, not
+    /// raw runs, once collapsing is in effect.
+    private var headerCount: Int {
+        if case .runs(let runs, _) = state { return latestPerWorkflow(runs).count }
+        return service.runs.count
+    }
+
+    /// Compact age label ("2h"). Empty for runs whose start time is unknown
+    /// (the provider falls back to .distantPast).
+    private func relativeAge(_ date: Date) -> String {
+        guard date != .distantPast else { return "" }
+        let seconds = max(0, Date().timeIntervalSince(date))
+        if seconds < 60 { return "now" }
+        if seconds < 3600 { return "\(Int(seconds / 60))m" }
+        if seconds < 86400 { return "\(Int(seconds / 3600))h" }
+        return "\(Int(seconds / 86400))d"
+    }
+
     var body: some View {
         VStack(spacing: 6) {
             header
@@ -123,7 +158,7 @@ private struct CICDRunsWidgetView: View {
                         Task { @MainActor in SettingsWindowController.shared.show() }
                     }
             }
-            Text("\(service.runs.count)")
+            Text("\(headerCount)")
                 .font(Theme.body(ts))
                 .foregroundStyle(Theme.text3(ts))
         }
@@ -152,7 +187,7 @@ private struct CICDRunsWidgetView: View {
             // the list to 50.
             TouchScrollView {
                 VStack(spacing: 4) {
-                    ForEach(runs) { run in
+                    ForEach(latestPerWorkflow(runs)) { run in
                         runRow(run)
                     }
                 }
@@ -204,6 +239,9 @@ private struct CICDRunsWidgetView: View {
                     .lineLimit(1)
             }
             Spacer()
+            Text(relativeAge(run.startedAt))
+                .font(Theme.label(ts))
+                .foregroundStyle(Theme.text3(ts).opacity(0.7))
             Text(statusLabel(run))
                 .font(Theme.label(ts))
                 .foregroundStyle(statusColor(run))

--- a/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
@@ -423,7 +423,7 @@ private struct ClockContainer: View {
     // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
     private var dayBarStyle: some View {
-        VStack(spacing: isCompact ? 6 : 10) {
+        VStack(spacing: isCompact ? 8 : 14) {
             // Day bar
             HStack(spacing: 0) {
                 ForEach(Array(dayNames.enumerated()), id: \.offset) { i, name in
@@ -439,8 +439,10 @@ private struct ClockContainer: View {
                 }
             }
 
-            // Time
-            timeRow(size: isCompact ? ts.fontSizeValue * 2.0 : ts.fontSizeValue * 2.5, weight: .semibold)
+            // Time — stretches to the same width as the day strip above:
+            // fittedTimeRow starts oversized and scales down to fit.
+            fittedTimeRow(weight: .semibold)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             if showDate && !isCompact {
                 Text(fullDate)
@@ -575,6 +577,30 @@ private struct ClockContainer: View {
         .monospacedDigit()
         .minimumScaleFactor(0.2)
         .lineLimit(1)
+    }
+
+    /// The time as ONE concatenated Text, so minimumScaleFactor scales every
+    /// segment together: at a deliberately oversized base size it always
+    /// shrinks to exactly fill its container's width (or height, whichever is
+    /// tighter) — no fixed font size involved.
+    private func fittedTimeRow(weight: Font.Weight) -> some View {
+        var text = Text(hourStr).foregroundStyle(Theme.text1(ts))
+            + Text(":").foregroundStyle(primary)
+            + Text(minStr).foregroundStyle(Theme.text1(ts))
+        if showSeconds {
+            text = text + Text(":").foregroundStyle(primary.opacity(0.4))
+                + Text(secStr).foregroundStyle(Theme.text3(ts))
+        }
+        if !use24h {
+            // Sized relative to the base so the ratio survives scaling.
+            text = text + Text(" " + ampm)
+                .font(Theme.font(size: 160, weight: .semibold, settings: ts))
+                .foregroundStyle(primary.opacity(0.6))
+        }
+        return text
+            .font(Theme.font(size: 400, weight: weight, settings: ts).monospacedDigit())
+            .minimumScaleFactor(0.02)
+            .lineLimit(1)
     }
 
     private var secondsBar: some View {

--- a/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
@@ -428,7 +428,7 @@ private struct ClockContainer: View {
             HStack(spacing: 0) {
                 ForEach(Array(dayNames.enumerated()), id: \.offset) { i, name in
                     Text(name)
-                        .font(.system(size: (isCompact ? 9 : 11) * ts.fontScale, weight: .heavy, design: ts.fontFamily.design))
+                        .font(.system(size: (isCompact ? 12 : 15) * ts.fontScale, weight: .heavy, design: ts.fontFamily.design))
                         .foregroundStyle(weekday == i + 1 ? .white : Theme.text3(ts))
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, isCompact ? 3 : 5)

--- a/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
@@ -424,9 +424,11 @@ private struct ClockContainer: View {
 
     private var dayBarStyle: some View {
         VStack(spacing: isCompact ? 8 : 14) {
-            // Day bar: a centered cluster of label-hugging chips above the
-            // clock, rather than a justified or column-stretched strip.
-            HStack(spacing: isCompact ? 3 : 6) {
+            // Day bar: justified chips that hug their labels, so the strip's
+            // visible edges equal the container's — and therefore the clock's
+            // — on every day. A first/last-day highlight capsule ends exactly
+            // at the edge instead of overhanging an inset clock.
+            HStack(spacing: 0) {
                 ForEach(Array(dayNames.enumerated()), id: \.offset) { i, name in
                     Text(name)
                         .font(.system(size: (isCompact ? 12 : 15) * ts.fontScale, weight: .heavy, design: ts.fontFamily.design))
@@ -437,14 +439,16 @@ private struct ClockContainer: View {
                             weekday == i + 1 ? primary.opacity(0.3) : Color.clear,
                             in: RoundedRectangle(cornerRadius: 4, style: .continuous)
                         )
+                    if i < dayNames.count - 1 { Spacer(minLength: 2) }
                 }
             }
-            .frame(maxWidth: .infinity)
 
             // Time — stretches to the same width as the day strip above:
-            // fittedTimeRow starts oversized and scales down to fit.
+            // fittedTimeRow starts oversized and scales down to fit. Width
+            // only: a greedy height would pin the day strip to the top edge,
+            // and the container centers the hugging group vertically instead.
             fittedTimeRow(weight: .semibold)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(maxWidth: .infinity)
 
             if showDate && !isCompact {
                 Text(fullDate)

--- a/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
@@ -424,11 +424,9 @@ private struct ClockContainer: View {
 
     private var dayBarStyle: some View {
         VStack(spacing: isCompact ? 8 : 14) {
-            // Day bar: justified chips that hug their labels, so the strip's
-            // visible edges equal the container's — and therefore the clock's
-            // — on every day. A first/last-day highlight capsule ends exactly
-            // at the edge instead of overhanging an inset clock.
-            HStack(spacing: 0) {
+            // Day bar: a centered cluster of label-hugging chips above the
+            // clock, rather than a justified or column-stretched strip.
+            HStack(spacing: isCompact ? 3 : 6) {
                 ForEach(Array(dayNames.enumerated()), id: \.offset) { i, name in
                     Text(name)
                         .font(.system(size: (isCompact ? 12 : 15) * ts.fontScale, weight: .heavy, design: ts.fontFamily.design))
@@ -439,9 +437,9 @@ private struct ClockContainer: View {
                             weekday == i + 1 ? primary.opacity(0.3) : Color.clear,
                             in: RoundedRectangle(cornerRadius: 4, style: .continuous)
                         )
-                    if i < dayNames.count - 1 { Spacer(minLength: 2) }
                 }
             }
+            .frame(maxWidth: .infinity)
 
             // Time — stretches to the same width as the day strip above:
             // fittedTimeRow starts oversized and scales down to fit.

--- a/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
@@ -167,13 +167,7 @@ private struct ClockContainer: View {
                     Circle().stroke(primary.opacity(0.2), lineWidth: 2)
                     // Hour ticks
                     ForEach(0..<12, id: \.self) { i in
-                        let angle = Double(i) / 12 * 2 * .pi - .pi / 2
-                        let inner = r * (i % 3 == 0 ? 0.75 : 0.85)
-                        Path { p in
-                            p.move(to: CGPoint(x: center.x + cos(angle) * inner, y: center.y + sin(angle) * inner))
-                            p.addLine(to: CGPoint(x: center.x + cos(angle) * r, y: center.y + sin(angle) * r))
-                        }
-                        .stroke(i % 3 == 0 ? primary.opacity(0.6) : Theme.text3(ts), lineWidth: i % 3 == 0 ? 2 : 1)
+                        hourTick(i, center: center, r: r)
                     }
                     // Hour hand
                     clockHand(center: center, length: r * 0.5, width: 3,
@@ -208,6 +202,21 @@ private struct ClockContainer: View {
                 }
             }
         }
+    }
+
+    // Extracted from analogStyle's ZStack: inline, the mixed CGFloat/Double
+    // arithmetic pushes the type checker past its expression time limit on
+    // Xcode 16.4's Swift compiler.
+    private func hourTick(_ i: Int, center: CGPoint, r: CGFloat) -> some View {
+        let angle = Double(i) / 12 * 2 * .pi - .pi / 2
+        let inner = r * (i % 3 == 0 ? 0.75 : 0.85)
+        let cosA = CGFloat(cos(angle))
+        let sinA = CGFloat(sin(angle))
+        return Path { p in
+            p.move(to: CGPoint(x: center.x + cosA * inner, y: center.y + sinA * inner))
+            p.addLine(to: CGPoint(x: center.x + cosA * r, y: center.y + sinA * r))
+        }
+        .stroke(i % 3 == 0 ? primary.opacity(0.6) : Theme.text3(ts), lineWidth: i % 3 == 0 ? 2 : 1)
     }
 
     private func clockHand(center: CGPoint, length: CGFloat, width: CGFloat, angle: Double, color: Color) -> some View {

--- a/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/ClockWidget.swift
@@ -424,18 +424,22 @@ private struct ClockContainer: View {
 
     private var dayBarStyle: some View {
         VStack(spacing: isCompact ? 8 : 14) {
-            // Day bar
+            // Day bar: justified chips that hug their labels, so the strip's
+            // visible edges equal the container's — and therefore the clock's
+            // — on every day. A first/last-day highlight capsule ends exactly
+            // at the edge instead of overhanging an inset clock.
             HStack(spacing: 0) {
                 ForEach(Array(dayNames.enumerated()), id: \.offset) { i, name in
                     Text(name)
                         .font(.system(size: (isCompact ? 12 : 15) * ts.fontScale, weight: .heavy, design: ts.fontFamily.design))
                         .foregroundStyle(weekday == i + 1 ? .white : Theme.text3(ts))
-                        .frame(maxWidth: .infinity)
+                        .padding(.horizontal, isCompact ? 5 : 7)
                         .padding(.vertical, isCompact ? 3 : 5)
                         .background(
                             weekday == i + 1 ? primary.opacity(0.3) : Color.clear,
                             in: RoundedRectangle(cornerRadius: 4, style: .continuous)
                         )
+                    if i < dayNames.count - 1 { Spacer(minLength: 2) }
                 }
             }
 

--- a/Sources/EdgeControl/Widgets/Info/DayProgressWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/DayProgressWidget.swift
@@ -6,7 +6,7 @@ public final class DayProgressWidget: DashboardWidget {
     public let description = "Visual progress of the current day with time remaining"
     public let iconName = "sun.max"
     public let category: WidgetCategory = .info
-    public let supportedSizes = WidgetSizeRange(min: .size(2, 2), max: .size(6, 3))
+    public let supportedSizes = WidgetSizeRange(min: .size(2, 1), max: .size(6, 3))
     public let defaultSize = WidgetSize.size(4, 2)
 
     public let configSchema: [ConfigSchemaEntry] = []
@@ -16,7 +16,9 @@ public final class DayProgressWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        DayProgressWidgetView(isCompact: size.width <= 3)
+        // The ring needs two rows of height; a 1-row placement always gets the
+        // linear title+bar layout, which fits a single 120px grid row.
+        DayProgressWidgetView(isCompact: size.width <= 3 && size.height >= 2)
     }
 }
 

--- a/Sources/EdgeControl/Widgets/Info/DayProgressWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/DayProgressWidget.swift
@@ -18,12 +18,13 @@ public final class DayProgressWidget: DashboardWidget {
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
         // The ring needs two rows of height; a 1-row placement always gets the
         // linear title+bar layout, which fits a single 120px grid row.
-        DayProgressWidgetView(isCompact: size.width <= 3 && size.height >= 2)
+        DayProgressWidgetView(isCompact: size.width <= 3 && size.height >= 2, isTall: size.height >= 2)
     }
 }
 
 private struct DayProgressWidgetView: View {
     let isCompact: Bool
+    let isTall: Bool
 
     @Environment(\.themeSettings) private var ts
     @State private var now = Date()
@@ -46,7 +47,7 @@ private struct DayProgressWidgetView: View {
     }
 
     var body: some View {
-        VStack(spacing: isCompact ? 6 : 10) {
+        VStack(spacing: isCompact ? 6 : (isTall ? 20 : 10)) {
             if isCompact {
                 // Compact: circular progress
                 ZStack {
@@ -65,6 +66,8 @@ private struct DayProgressWidgetView: View {
                 .aspectRatio(1, contentMode: .fit)
                 .padding(4)
             } else {
+                // Center the linear stack in 2+ row cells; 1-row keeps its top-aligned fit.
+                if isTall { Spacer(minLength: 0) }
                 HStack(spacing: 8) {
                     Image(systemName: "sun.max.fill")
                         .font(.system(size: 18 * ts.fontScale))
@@ -92,7 +95,7 @@ private struct DayProgressWidgetView: View {
                             .frame(width: geo.size.width * dayProgress)
                     }
                 }
-                .frame(height: 10)
+                .frame(height: isTall ? 14 : 10)
 
                 HStack {
                     Text("REMAINING")

--- a/Sources/EdgeControl/Widgets/Info/RemindersWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/RemindersWidget.swift
@@ -11,8 +11,16 @@ public final class RemindersWidget: DashboardWidget {
     public let defaultSize = WidgetSize.size(4, 3)
 
     public let configSchema: [ConfigSchemaEntry] = [
-        // Empty means the system default list; any real list name works.
-        ConfigSchemaEntry(key: "list", label: "List (empty = default)", type: .text, defaultValue: .string("")),
+        // The page manager swaps this for a picker of real list names once
+        // the service has discovered them; "default" = the system default.
+        ConfigSchemaEntry(key: "list", label: "List", type: .text, defaultValue: .string("default")),
+        // Items with due dates sort due-first (overdue on top); this orders
+        // the undated remainder.
+        ConfigSchemaEntry(key: "undatedSort", label: "Undated Sort", type: .picker,
+                          defaultValue: .string("newest first"),
+                          options: ["newest first", "oldest first", "recently updated", "least recently updated"]),
+        ConfigSchemaEntry(key: "newDueToday", label: "New Reminders Due Today", type: .toggle,
+                          defaultValue: .bool(false)),
     ]
     public let defaultColors = WidgetColors(primary: .orange)
 
@@ -26,7 +34,9 @@ public final class RemindersWidget: DashboardWidget {
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
         RemindersWidgetView(
             service: service,
-            configuredList: config.string("list"),
+            configuredList: config.string("list", default: "default"),
+            undatedSort: config.string("undatedSort", default: "newest first"),
+            newDueToday: config.bool("newDueToday", default: false),
             isCompact: size.height <= 2
         )
     }
@@ -37,6 +47,8 @@ private struct RemindersWidgetView: View {
     @EnvironmentObject private var model: AppModel
     @Environment(\.themeSettings) private var ts
     let configuredList: String
+    let undatedSort: String
+    let newDueToday: Bool
     let isCompact: Bool
 
     @State private var draft = ""
@@ -47,7 +59,8 @@ private struct RemindersWidgetView: View {
         VStack(spacing: isCompact ? 6 : 10) {
             if !isCompact {
                 WidgetHeader(
-                    title: configuredList.isEmpty ? "REMINDERS" : configuredList.uppercased(),
+                    title: (configuredList.isEmpty || configuredList == "default")
+                        ? "REMINDERS" : configuredList.uppercased(),
                     color: primary
                 )
             }
@@ -63,7 +76,7 @@ private struct RemindersWidgetView: View {
                 } else {
                     TouchScrollView {
                         VStack(spacing: 2) {
-                            ForEach(service.items) { item in
+                            ForEach(sortedItems) { item in
                                 reminderRow(item)
                             }
                         }
@@ -78,7 +91,7 @@ private struct RemindersWidgetView: View {
                     .padding(.vertical, 5)
                     .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
                     .onSubmit {
-                        service.add(title: draft)
+                        service.add(title: draft, dueToday: newDueToday)
                         draft = ""
                     }
             }
@@ -88,6 +101,27 @@ private struct RemindersWidgetView: View {
         // The service is shared; the placed widget's config decides the list.
         .onAppear { service.listName = configuredList }
         .onChange(of: configuredList) { _, newValue in service.listName = newValue }
+    }
+
+    /// Due items first, soonest (so overdue tops the list); the undated
+    /// tail ordered by the configured secondary sort.
+    private var sortedItems: [RemindersService.Item] {
+        let items = service.items
+        let dated = items.filter { $0.dueDate != nil }
+            .sorted { ($0.dueDate ?? .distantPast) < ($1.dueDate ?? .distantPast) }
+        let undated = items.filter { $0.dueDate == nil }.sorted { a, b in
+            switch undatedSort {
+            case "oldest first":
+                (a.created ?? .distantPast) < (b.created ?? .distantPast)
+            case "recently updated":
+                (a.modified ?? .distantPast) > (b.modified ?? .distantPast)
+            case "least recently updated":
+                (a.modified ?? .distantPast) < (b.modified ?? .distantPast)
+            default:
+                (a.created ?? .distantPast) > (b.created ?? .distantPast)
+            }
+        }
+        return dated + undated
     }
 
     private func reminderRow(_ item: RemindersService.Item) -> some View {

--- a/Sources/EdgeControl/Widgets/Info/RemindersWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/RemindersWidget.swift
@@ -20,10 +20,13 @@ public final class RemindersWidget: DashboardWidget {
                           defaultValue: .string("newest first"),
                           options: ["newest first", "oldest first", "recently updated", "least recently updated"]),
         ConfigSchemaEntry(key: "newDueToday", label: "New Reminders Due Today", type: .toggle,
-                          defaultValue: .bool(false)),
-        // The time a due-today reminder fires when no sooner time was given.
-        ConfigSchemaEntry(key: "dueTime", label: "Due Time (HH:mm)", type: .text,
-                          defaultValue: .string("18:00")),
+                          defaultValue: .bool(false),
+                          help: "Reminders added from this widget get a due date of today."),
+        ConfigSchemaEntry(key: "dueTime", label: "Due Time", type: .time,
+                          defaultValue: .string("18:00"),
+                          help: "When Due Today is on and no \"in…\" offset is typed, "
+                              + "new reminders come due — and notify — at this time. "
+                              + "A typed offset like \":30\" or \"2:15\" always wins."),
     ]
     public let defaultColors = WidgetColors(primary: .orange)
 

--- a/Sources/EdgeControl/Widgets/Info/RemindersWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/RemindersWidget.swift
@@ -21,6 +21,9 @@ public final class RemindersWidget: DashboardWidget {
                           options: ["newest first", "oldest first", "recently updated", "least recently updated"]),
         ConfigSchemaEntry(key: "newDueToday", label: "New Reminders Due Today", type: .toggle,
                           defaultValue: .bool(false)),
+        // The time a due-today reminder fires when no sooner time was given.
+        ConfigSchemaEntry(key: "dueTime", label: "Due Time (HH:mm)", type: .text,
+                          defaultValue: .string("18:00")),
     ]
     public let defaultColors = WidgetColors(primary: .orange)
 
@@ -37,6 +40,7 @@ public final class RemindersWidget: DashboardWidget {
             configuredList: config.string("list", default: "default"),
             undatedSort: config.string("undatedSort", default: "newest first"),
             newDueToday: config.bool("newDueToday", default: false),
+            dueTime: config.string("dueTime", default: "18:00"),
             isCompact: size.height <= 2
         )
     }
@@ -49,9 +53,11 @@ private struct RemindersWidgetView: View {
     let configuredList: String
     let undatedSort: String
     let newDueToday: Bool
+    let dueTime: String
     let isCompact: Bool
 
     @State private var draft = ""
+    @State private var remindIn = ""
 
     private var primary: Color { Theme.widgetPrimary("reminders", ts: ts, default: .orange) }
 
@@ -83,17 +89,22 @@ private struct RemindersWidgetView: View {
                     }
                 }
 
-                TextField("Add reminder…", text: $draft)
-                    .textFieldStyle(.plain)
-                    .font(Theme.body(ts))
-                    .foregroundStyle(Theme.text1(ts))
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 5)
-                    .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-                    .onSubmit {
-                        service.add(title: draft, dueToday: newDueToday)
-                        draft = ""
-                    }
+                HStack(spacing: 6) {
+                    TextField("Add reminder…", text: $draft)
+                        .textFieldStyle(.plain)
+                        .onSubmit { createReminder() }
+                    // ":30" = 30 min, "2" = 2 hours, "2:15" = 2h15m.
+                    TextField("in…", text: $remindIn)
+                        .textFieldStyle(.plain)
+                        .frame(width: 44)
+                        .multilineTextAlignment(.trailing)
+                        .onSubmit { createReminder() }
+                }
+                .font(Theme.body(ts))
+                .foregroundStyle(Theme.text1(ts))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 5)
+                .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
             }
         }
         .padding(isCompact ? Theme.compactPadding : Theme.widgetPadding)
@@ -101,6 +112,40 @@ private struct RemindersWidgetView: View {
         // The service is shared; the placed widget's config decides the list.
         .onAppear { service.listName = configuredList }
         .onChange(of: configuredList) { _, newValue in service.listName = newValue }
+    }
+
+    private func createReminder() {
+        let due = remindInInterval(remindIn).map { Date().addingTimeInterval($0) }
+            ?? defaultDueDate()
+        service.add(title: draft, due: due)
+        draft = ""
+        remindIn = ""
+    }
+
+    /// ":30" = 30 minutes, ":03" = 3 minutes, "2" = 2 hours, "2:15" = two
+    /// hours fifteen. Empty or unparseable means no offset.
+    private func remindInInterval(_ s: String) -> TimeInterval? {
+        let t = s.trimmingCharacters(in: .whitespaces)
+        guard !t.isEmpty else { return nil }
+        if t.hasPrefix(":") {
+            return Int(t.dropFirst()).map { TimeInterval($0 * 60) }
+        }
+        if t.contains(":") {
+            let parts = t.split(separator: ":")
+            guard parts.count == 2, let h = Int(parts[0]), let m = Int(parts[1]) else { return nil }
+            return TimeInterval(h * 3600 + m * 60)
+        }
+        return Int(t).map { TimeInterval($0 * 3600) }
+    }
+
+    /// Today at the configured due time — the fallback when Due Today is on
+    /// and no remind-in was given.
+    private func defaultDueDate() -> Date? {
+        guard newDueToday else { return nil }
+        let parts = dueTime.split(separator: ":")
+        let hour = parts.count == 2 ? Int(parts[0]) ?? 18 : 18
+        let minute = parts.count == 2 ? Int(parts[1]) ?? 0 : 0
+        return Calendar.current.date(bySettingHour: hour, minute: minute, second: 0, of: Date())
     }
 
     /// Due items first, soonest (so overdue tops the list); the undated
@@ -139,7 +184,10 @@ private struct RemindersWidgetView: View {
                 .lineLimit(1)
             Spacer()
             if let due = item.dueDate {
-                Text(Self.dueFormatter.string(from: due))
+                // Same-day reminders show their time; others show the date.
+                Text(Calendar.current.isDateInToday(due)
+                    ? Self.timeFormatter.string(from: due)
+                    : Self.dueFormatter.string(from: due))
                     .font(Theme.label(ts))
                     .foregroundStyle(due < Date() ? Theme.accentRed : Theme.text3(ts))
             }
@@ -162,6 +210,12 @@ private struct RemindersWidgetView: View {
     private static let dueFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "MMM d"
+        return f
+    }()
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "h:mm a"
         return f
     }()
 }

--- a/Sources/EdgeControl/Widgets/Info/RemindersWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/RemindersWidget.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+public final class RemindersWidget: DashboardWidget {
+    public let widgetId = "reminders"
+    public let displayName = "Reminders"
+    public let description = "Your real Reminders list — check off and add items in place"
+    public let iconName = "checklist"
+    public let category: WidgetCategory = .info
+    public let requiredServices: Set<ServiceKey> = [.reminders]
+    public let supportedSizes = WidgetSizeRange(min: .size(3, 2), max: .size(8, 6))
+    public let defaultSize = WidgetSize.size(4, 3)
+
+    public let configSchema: [ConfigSchemaEntry] = [
+        // Empty means the system default list; any real list name works.
+        ConfigSchemaEntry(key: "list", label: "List (empty = default)", type: .text, defaultValue: .string("")),
+    ]
+    public let defaultColors = WidgetColors(primary: .orange)
+
+    private let service: RemindersService
+
+    public init(service: RemindersService) {
+        self.service = service
+    }
+
+    @MainActor
+    public func body(size: WidgetSize, config: WidgetConfig) -> any View {
+        RemindersWidgetView(
+            service: service,
+            configuredList: config.string("list"),
+            isCompact: size.height <= 2
+        )
+    }
+}
+
+private struct RemindersWidgetView: View {
+    @ObservedObject var service: RemindersService
+    @EnvironmentObject private var model: AppModel
+    @Environment(\.themeSettings) private var ts
+    let configuredList: String
+    let isCompact: Bool
+
+    @State private var draft = ""
+
+    private var primary: Color { Theme.widgetPrimary("reminders", ts: ts, default: .orange) }
+
+    var body: some View {
+        VStack(spacing: isCompact ? 6 : 10) {
+            if !isCompact {
+                WidgetHeader(
+                    title: configuredList.isEmpty ? "REMINDERS" : configuredList.uppercased(),
+                    color: primary
+                )
+            }
+
+            switch service.access {
+            case .unknown:
+                centeredNote("Waiting for Reminders access…")
+            case .denied:
+                centeredNote("Grant access in System Settings → Privacy → Reminders")
+            case .granted:
+                if service.items.isEmpty {
+                    centeredNote("All clear")
+                } else {
+                    TouchScrollView {
+                        VStack(spacing: 2) {
+                            ForEach(service.items) { item in
+                                reminderRow(item)
+                            }
+                        }
+                    }
+                }
+
+                TextField("Add reminder…", text: $draft)
+                    .textFieldStyle(.plain)
+                    .font(Theme.body(ts))
+                    .foregroundStyle(Theme.text1(ts))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 5)
+                    .background(Color.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .onSubmit {
+                        service.add(title: draft)
+                        draft = ""
+                    }
+            }
+        }
+        .padding(isCompact ? Theme.compactPadding : Theme.widgetPadding)
+        .widgetCard()
+        // The service is shared; the placed widget's config decides the list.
+        .onAppear { service.listName = configuredList }
+        .onChange(of: configuredList) { _, newValue in service.listName = newValue }
+    }
+
+    private func reminderRow(_ item: RemindersService.Item) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "circle")
+                .font(.system(size: 15 * ts.fontScale))
+                .foregroundStyle(primary)
+                .touchTappable(id: "reminder-done-\(item.id)", registry: model.touchService.zoneRegistry) {
+                    let id = item.id
+                    Task { @MainActor in model.remindersService.complete(id: id) }
+                }
+            Text(item.title)
+                .font(Theme.body(ts))
+                .foregroundStyle(Theme.text1(ts))
+                .lineLimit(1)
+            Spacer()
+            if let due = item.dueDate {
+                Text(Self.dueFormatter.string(from: due))
+                    .font(Theme.label(ts))
+                    .foregroundStyle(due < Date() ? Theme.accentRed : Theme.text3(ts))
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func centeredNote(_ text: String) -> some View {
+        VStack {
+            Spacer()
+            Text(text)
+                .font(Theme.label(ts))
+                .foregroundStyle(Theme.text3(ts))
+                .multilineTextAlignment(.center)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private static let dueFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
+}

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 public final class StickyNoteWidget: DashboardWidget {
     public let widgetId = "sticky-note"
@@ -34,6 +35,8 @@ public final class StickyNoteWidget: DashboardWidget {
     }
 }
 
+/// The note stores links as inline markdown — `[title](url)` — and renders
+/// them as tappable titles. No other markdown is interpreted.
 private struct StickyNoteWidgetView: View {
     let note: String
     let colorName: String
@@ -46,6 +49,12 @@ private struct StickyNoteWidgetView: View {
     @Environment(\.themeSettings) private var ts
     @State private var draft = ""
     @State private var seeded = false
+    @State private var isEditingNote = false
+    // A bare-URL paste prompts for a title; the URL and the cursor offset it
+    // will be inserted at wait here while the prompt is up.
+    @State private var pendingLinkURL: String?
+    @State private var pendingInsertOffset: Int = 0
+    @State private var linkTitle = ""
 
     private var primary: Color {
         switch colorName {
@@ -62,28 +71,119 @@ private struct StickyNoteWidgetView: View {
     }
 
     var body: some View {
-        TextEditor(text: $draft)
-            .font(Theme.body(ts))
-            .foregroundStyle(Theme.text1(ts))
-            .scrollContentBackground(.hidden)
-            .scrollIndicators(.never)
-            .padding(Theme.compactPadding)
-            .background(primary.opacity(tintOpacity))
-            .widgetCard()
-            .onAppear {
-                if !seeded {
-                    draft = note
-                    seeded = true
-                }
+        Group {
+            if isEditingNote {
+                editor
+            } else {
+                display
             }
-            // External edits (settings field, layout import) win over a
-            // stale on-screen draft only when they actually differ.
-            .onChange(of: note) { _, newValue in
-                if newValue != draft { draft = newValue }
+        }
+        .padding(Theme.compactPadding)
+        .background(primary.opacity(tintOpacity))
+        .widgetCard()
+        .onAppear {
+            if !seeded {
+                draft = note
+                seeded = true
             }
-            .onChange(of: draft) { _, newValue in
-                save(newValue)
+        }
+        // External edits (settings field, layout import) win over a
+        // stale on-screen draft only when they actually differ.
+        .onChange(of: note) { _, newValue in
+            if newValue != draft { draft = newValue }
+        }
+        .onChange(of: draft) { _, newValue in
+            save(newValue)
+        }
+        .alert("Name this link", isPresented: Binding(
+            get: { pendingLinkURL != nil },
+            set: { if !$0 { pendingLinkURL = nil } }
+        )) {
+            TextField("Title", text: $linkTitle)
+            Button("Add Link") { commitPendingLink() }
+            Button("Cancel", role: .cancel) { pendingLinkURL = nil }
+        } message: {
+            Text("The note shows the title; the link stays underneath.")
+        }
+    }
+
+    // MARK: - Display mode
+
+    private var display: some View {
+        ZStack(alignment: .topLeading) {
+            // Empty-area clicks enter editing; clicks on rendered text (and
+            // its links) go to the Text itself.
+            Color.white.opacity(0.001)
+                .onTapGesture { isEditingNote = true }
+            if draft.isEmpty {
+                Text("Click to write…")
+                    .font(Theme.body(ts))
+                    .foregroundStyle(Theme.text3(ts))
+            } else {
+                Text(rendered)
+                    .font(Theme.body(ts))
+                    .foregroundStyle(Theme.text1(ts))
+                    .tint(primary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            Button {
+                isEditingNote = true
+            } label: {
+                Image(systemName: "pencil.circle.fill")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Theme.text3(ts).opacity(0.6))
+            }
+            .buttonStyle(.plain)
+            .help("Edit note")
+        }
+    }
+
+    private var rendered: AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(
+            interpretedSyntax: .inlineOnlyPreservingWhitespace
+        )
+        return (try? AttributedString(markdown: draft, options: options))
+            ?? AttributedString(draft)
+    }
+
+    // MARK: - Edit mode
+
+    @ViewBuilder
+    private var editor: some View {
+        VStack(alignment: .trailing, spacing: 4) {
+            if #available(macOS 15.0, *) {
+                LinkingTextEditor(
+                    text: $draft,
+                    onPromptLink: { url, offset in
+                        linkTitle = ""
+                        pendingInsertOffset = offset
+                        pendingLinkURL = url
+                    }
+                )
+                .font(Theme.body(ts))
+            } else {
+                TextEditor(text: $draft)
+                    .font(Theme.body(ts))
+                    .scrollContentBackground(.hidden)
+                    .scrollIndicators(.never)
+            }
+            Button("Done") { isEditingNote = false }
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .keyboardShortcut(.escape, modifiers: [])
+        }
+    }
+
+    private func commitPendingLink() {
+        guard let url = pendingLinkURL else { return }
+        let title = linkTitle.trimmingCharacters(in: .whitespaces)
+        let display = title.isEmpty ? (URL(string: url)?.host ?? "link") : title
+        let insertion = "[\(display)](\(url))"
+        let offset = min(max(pendingInsertOffset, 0), draft.count)
+        let idx = draft.index(draft.startIndex, offsetBy: offset)
+        draft.insert(contentsOf: insertion, at: idx)
+        pendingLinkURL = nil
     }
 
     private func save(_ text: String) {
@@ -95,5 +195,75 @@ private struct StickyNoteWidgetView: View {
         config["_pageId"] = nil
         config["_instanceId"] = nil
         layoutEngine.updateWidgetConfig(pageId: pageId, instanceId: instanceId, config: config)
+    }
+}
+
+// MARK: - Linking editor (macOS 15+)
+
+/// TextEditor with selection tracking and paste interception: pasting a URL
+/// over selected text turns the selection into `[selection](url)`; pasting a
+/// bare URL asks the parent to prompt for a title. Everything else pastes
+/// normally.
+@available(macOS 15.0, *)
+private struct LinkingTextEditor: View {
+    @Binding var text: String
+    /// (url, character offset to insert at) — parent shows the title prompt.
+    let onPromptLink: (String, Int) -> Void
+
+    @State private var selection: TextSelection?
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        TextEditor(text: $text, selection: $selection)
+            .scrollContentBackground(.hidden)
+            .scrollIndicators(.never)
+            .focused($focused)
+            .onAppear { focused = true }
+            .onPasteCommand(of: [UTType.url, UTType.plainText]) { _ in
+                handlePaste()
+            }
+    }
+
+    private func handlePaste() {
+        guard let pasted = NSPasteboard.general.string(forType: .string)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) else { return }
+
+        let selectedRange = currentRange()
+        guard isLink(pasted) else {
+            // Not a URL: reproduce a normal paste at the selection.
+            replace(range: selectedRange, with: pasted)
+            return
+        }
+
+        if let range = selectedRange, !range.isEmpty {
+            // Slack-style: the selected words become the link title.
+            let title = String(text[range])
+            replace(range: range, with: "[\(title)](\(pasted))")
+        } else {
+            let idx = selectedRange?.lowerBound ?? text.endIndex
+            onPromptLink(pasted, text.distance(from: text.startIndex, to: idx))
+        }
+    }
+
+    private func currentRange() -> Range<String.Index>? {
+        guard let selection, case .selection(let range) = selection.indices else { return nil }
+        return range
+    }
+
+    private func replace(range: Range<String.Index>?, with insertion: String) {
+        // Selection indices go stale the moment the string changes; clear
+        // first so SwiftUI never resolves them against the new text.
+        selection = nil
+        if let range {
+            text.replaceSubrange(range, with: insertion)
+        } else {
+            text.append(insertion)
+        }
+    }
+
+    private func isLink(_ s: String) -> Bool {
+        guard !s.contains(" "), let url = URL(string: s),
+              let scheme = url.scheme?.lowercased() else { return false }
+        return (scheme == "http" || scheme == "https") && url.host != nil
     }
 }

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -339,32 +339,24 @@ private final class LinkPasteTextView: NSTextView {
     }
 
     func applyCheckboxCursors() {
+        // Pointer cursor only. The glyph stays at body size: caret height
+        // follows line height, and line height follows the tallest glyph, so
+        // an enlarged box either grows the caret or squashes the line — both
+        // tried, both worse. This pass also repairs notes saved during the
+        // oversized-glyph experiments.
         guard let storage = textStorage else { return }
         let ns = storage.string as NSString
-        // Enlarged as a tap target — but the line height is clamped to the
-        // body's, because the caret spans the line: an unclamped 2x glyph
-        // made the insertion cursor giant. The box's ink is small within its
-        // em square, so 1.5x fits a body-height line.
-        let size = defaultFont.pointSize * 1.5
-        let glyphFont = NSFont(descriptor: defaultFont.fontDescriptor, size: size)
-            ?? NSFont.systemFont(ofSize: size)
-        let bodyLine = defaultFont.ascender + abs(defaultFont.descender) + defaultFont.leading
-        let para = NSMutableParagraphStyle()
-        para.minimumLineHeight = bodyLine
-        para.maximumLineHeight = bodyLine * 1.12
         var idx = 0
         while idx < ns.length {
             let ch = ns.substring(with: NSRange(location: idx, length: 1))
             if ch == "☐" || ch == "☑" {
+                let range = NSRange(location: idx, length: 1)
                 storage.addAttributes(
-                    [
-                        .cursor: NSCursor.pointingHand,
-                        .font: glyphFont,
-                        .paragraphStyle: para,
-                        .baselineOffset: -(size - defaultFont.pointSize) * 0.15,
-                    ],
-                    range: NSRange(location: idx, length: 1)
+                    [.cursor: NSCursor.pointingHand, .font: defaultFont],
+                    range: range
                 )
+                storage.removeAttribute(.paragraphStyle, range: range)
+                storage.removeAttribute(.baselineOffset, range: range)
             }
             idx += 1
         }

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -1030,6 +1030,28 @@ private final class LinkPasteTextView: NSTextView {
         super.mouseDown(with: event)
     }
 
+    /// Format > Toggle Checked (Cmd+Return): flips the checkbox of every
+    /// checkbox line the caret or selection touches; other lines are left
+    /// alone. Same write path as clicking the box.
+    @objc func toggleChecked(_ sender: Any?) {
+        guard let storage = textStorage, storage.length > 0 else { return }
+        let ns = string as NSString
+        let lines = ns.lineRange(for: selectedRange())
+        var location = lines.location
+        while location < max(NSMaxRange(lines), lines.location + 1), location < ns.length {
+            let paragraph = ns.lineRange(for: NSRange(location: location, length: 0))
+            if paragraph.length > 0,
+               let box = storage.attribute(.attachment, at: paragraph.location, effectiveRange: nil) as? CheckboxAttachment {
+                let range = NSRange(location: paragraph.location, length: 1)
+                if shouldChangeText(in: range, replacementString: nil) {
+                    storage.replaceCharacters(in: range, with: checkboxOnly(checked: !box.checked))
+                    didChangeText()
+                }
+            }
+            location = paragraph.location + paragraph.length
+        }
+    }
+
     // MARK: Strikethrough (Format menu)
 
     @objc func toggleStrikethrough(_ sender: Any?) {

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -86,7 +86,19 @@ private struct StickyNoteWidgetView: View {
             legacyMarkdown: note,
             baseFont: RichStickyTextView.makeFont(family: fontFamily, size: fontSize * ts.fontScale),
             textColor: NSColor(Theme.text1(ts)),
-            linkColor: NSColor(primary)
+            linkColor: NSColor(primary),
+            onFontSizeDelta: { delta in
+                guard !instanceId.isEmpty else { return }
+                var config = baseConfig
+                config["fontSize"] = .double(min(24, max(10, fontSize + delta)))
+                // Carry the live drafts so the size write can't clobber
+                // newer text than the config snapshot holds.
+                config["rtf"] = .string(rtfDraft)
+                config["note"] = .string(plainDraft)
+                config["_pageId"] = nil
+                config["_instanceId"] = nil
+                layoutEngine.updateWidgetConfig(pageId: pageId, instanceId: instanceId, config: config)
+            }
         )
         .padding(Theme.compactPadding)
         .background(primary.opacity(tintOpacity))
@@ -141,6 +153,7 @@ private struct RichStickyTextView: NSViewRepresentable {
     let baseFont: NSFont
     let textColor: NSColor
     let linkColor: NSColor
+    let onFontSizeDelta: (Double) -> Void
 
     func makeNSView(context: Context) -> NSScrollView {
         let textView = LinkPasteTextView()
@@ -174,6 +187,7 @@ private struct RichStickyTextView: NSViewRepresentable {
             )
         }
         textView.accentColor = linkColor
+        textView.onFontSizeDelta = onFontSizeDelta
         textView.typingAttributes = [.font: baseFont, .foregroundColor: textColor]
         textView.normalizeCheckboxes()
 
@@ -189,6 +203,7 @@ private struct RichStickyTextView: NSViewRepresentable {
         guard let textView = scroll.documentView as? LinkPasteTextView else { return }
         textView.insertionPointColor = textColor
         textView.accentColor = linkColor
+        textView.onFontSizeDelta = onFontSizeDelta
         // Reflow the whole note when the configured font family/size changes,
         // preserving bold/italic traits and relative (heading) sizes.
         if context.coordinator.appliedFontKey != fontKey {
@@ -344,7 +359,11 @@ private final class LinkPasteTextView: NSTextView {
     var defaultFont: NSFont = .systemFont(ofSize: 13)
     var defaultColor: NSColor = .white
     var accentColor: NSColor = .systemYellow
+    var onFontSizeDelta: ((Double) -> Void)?
     private var isNormalizing = false
+
+    @objc func increaseFontSize(_ sender: Any?) { onFontSizeDelta?(1) }
+    @objc func decreaseFontSize(_ sender: Any?) { onFontSizeDelta?(-1) }
 
     private var bodyAttributes: [NSAttributedString.Key: Any] {
         [.font: defaultFont, .foregroundColor: defaultColor,
@@ -495,7 +514,10 @@ private final class LinkPasteTextView: NSTextView {
         // The bullet waits for the first character after "- ": converting on
         // the space itself created a confusing interstitial state and stole
         // the "[" that starts a checkbox.
-        if str.count == 1, str != "[" { convertDashIfPending() }
+        if str.count == 1, str != "[" {
+            if (str == "-" || str == "*"), convertCheckboxToBullet() { return }
+            convertDashIfPending()
+        }
         super.insertText(insertString, replacementRange: replacementRange)
     }
 
@@ -558,8 +580,25 @@ private final class LinkPasteTextView: NSTextView {
         let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
         guard loc - lineRange.location == 2 else { return }
         let prefixRange = NSRange(location: lineRange.location, length: 2)
-        guard ns.substring(with: prefixRange) == "- " else { return }
+        let prefix = ns.substring(with: prefixRange)
+        guard prefix == "- " || prefix == "* " else { return }
         replace(prefixRange, with: NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes))
+    }
+
+    /// Typing "-" or "*" right after a fresh checkbox marker switches the
+    /// item to a bullet — changing your mind shouldn't need deleting.
+    private func convertCheckboxToBullet() -> Bool {
+        guard let storage = textStorage else { return false }
+        let ns = string as NSString
+        let loc = selectedRange().location
+        let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
+        guard loc - lineRange.location == 2,
+              ns.substring(with: NSRange(location: lineRange.location, length: 2)) == "\u{FFFC}\u{00A0}",
+              storage.attribute(.attachment, at: lineRange.location, effectiveRange: nil) is CheckboxAttachment
+        else { return false }
+        let markerRange = NSRange(location: lineRange.location, length: 2)
+        replace(markerRange, with: NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes))
+        return true
     }
 
     /// Pressing return on a line that is nothing but a list marker deletes

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -211,6 +211,7 @@ private struct LinkingTextEditor: View {
     let onPromptLink: (String, Int) -> Void
 
     @State private var selection: TextSelection?
+    @State private var keyMonitor: Any?
     @FocusState private var focused: Bool
 
     var body: some View {
@@ -218,23 +219,32 @@ private struct LinkingTextEditor: View {
             .scrollContentBackground(.hidden)
             .scrollIndicators(.never)
             .focused($focused)
-            .onAppear { focused = true }
-            .onPasteCommand(of: [UTType.url, UTType.plainText]) { _ in
-                handlePaste()
+            .onAppear {
+                focused = true
+                // onPasteCommand never fires here: the focused NSTextView
+                // consumes Cmd+V itself. A local monitor sees the keystroke
+                // first; URL pastes are ours, everything else passes through
+                // to the text view's native paste.
+                keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+                    guard focused,
+                          event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
+                          event.charactersIgnoringModifiers?.lowercased() == "v",
+                          let pasted = NSPasteboard.general.string(forType: .string)?
+                              .trimmingCharacters(in: .whitespacesAndNewlines),
+                          isLink(pasted)
+                    else { return event }
+                    handleLinkPaste(pasted)
+                    return nil
+                }
+            }
+            .onDisappear {
+                if let keyMonitor { NSEvent.removeMonitor(keyMonitor) }
+                keyMonitor = nil
             }
     }
 
-    private func handlePaste() {
-        guard let pasted = NSPasteboard.general.string(forType: .string)?
-            .trimmingCharacters(in: .whitespacesAndNewlines) else { return }
-
+    private func handleLinkPaste(_ pasted: String) {
         let selectedRange = currentRange()
-        guard isLink(pasted) else {
-            // Not a URL: reproduce a normal paste at the selection.
-            replace(range: selectedRange, with: pasted)
-            return
-        }
-
         if let range = selectedRange, !range.isEmpty {
             // Slack-style: the selected words become the link title.
             let title = String(text[range])

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -87,18 +87,8 @@ private struct StickyNoteWidgetView: View {
             baseFont: RichStickyTextView.makeFont(family: fontFamily, size: fontSize * ts.fontScale),
             textColor: NSColor(Theme.text1(ts)),
             linkColor: NSColor(primary),
-            onFontSizeDelta: { delta in
-                guard !instanceId.isEmpty else { return }
-                var config = baseConfig
-                config["fontSize"] = .double(min(24, max(10, fontSize + delta)))
-                // Carry the live drafts so the size write can't clobber
-                // newer text than the config snapshot holds.
-                config["rtf"] = .string(rtfDraft)
-                config["note"] = .string(plainDraft)
-                config["_pageId"] = nil
-                config["_instanceId"] = nil
-                layoutEngine.updateWidgetConfig(pageId: pageId, instanceId: instanceId, config: config)
-            }
+            onFontSizeDelta: { delta in persistFontSize(fontSize + delta) },
+            onFontSizeReset: { persistFontSize(13) }
         )
         .padding(Theme.compactPadding)
         .background(primary.opacity(tintOpacity))
@@ -131,6 +121,20 @@ private struct StickyNoteWidgetView: View {
         }
     }
 
+    /// 13 is the schema default; Cmd+0 snaps back to it.
+    private func persistFontSize(_ newSize: Double) {
+        guard !instanceId.isEmpty else { return }
+        var config = baseConfig
+        config["fontSize"] = .double(min(24, max(10, newSize)))
+        // Carry the live drafts so the size write can't clobber newer text
+        // than the config snapshot holds.
+        config["rtf"] = .string(rtfDraft)
+        config["note"] = .string(plainDraft)
+        config["_pageId"] = nil
+        config["_instanceId"] = nil
+        layoutEngine.updateWidgetConfig(pageId: pageId, instanceId: instanceId, config: config)
+    }
+
     private func save() {
         guard !instanceId.isEmpty, rtfDraft != rtf else { return }
         // Strip the injected identity keys: they describe the render pass,
@@ -154,6 +158,7 @@ private struct RichStickyTextView: NSViewRepresentable {
     let textColor: NSColor
     let linkColor: NSColor
     let onFontSizeDelta: (Double) -> Void
+    let onFontSizeReset: () -> Void
 
     func makeNSView(context: Context) -> NSScrollView {
         let textView = LinkPasteTextView()
@@ -188,6 +193,7 @@ private struct RichStickyTextView: NSViewRepresentable {
         }
         textView.accentColor = linkColor
         textView.onFontSizeDelta = onFontSizeDelta
+        textView.onFontSizeReset = onFontSizeReset
         textView.typingAttributes = [.font: baseFont, .foregroundColor: textColor]
         textView.normalizeCheckboxes()
 
@@ -204,21 +210,31 @@ private struct RichStickyTextView: NSViewRepresentable {
         textView.insertionPointColor = textColor
         textView.accentColor = linkColor
         textView.onFontSizeDelta = onFontSizeDelta
-        // Reflow the whole note when the configured font family/size changes,
-        // preserving bold/italic traits and relative (heading) sizes.
-        if context.coordinator.appliedFontKey != fontKey {
+        textView.onFontSizeReset = onFontSizeReset
+        let fontChanged = context.coordinator.appliedFontKey != fontKey
+        // Reload only on a genuine external change — and never on the pass
+        // that changes the font: the binding still holds pre-reflow RTF then,
+        // and reloading from it would undo the text scaling while the
+        // checkbox images resized (the bug that shipped first).
+        if !fontChanged,
+           Self.rtfString(textView.attributedString()) != rtfBase64,
+           let restored = Self.fromRTF(rtfBase64) {
+            textView.textStorage?.setAttributedString(restored)
+            textView.normalizeCheckboxes()
+        }
+        // Reflow when the configured family/size changes, preserving traits
+        // and relative heading sizes; checkboxes redraw to match.
+        if fontChanged {
             let ratio = baseFont.pointSize / textView.defaultFont.pointSize
             reapplyBaseFont(in: textView, ratio: ratio)
             textView.defaultFont = baseFont
             context.coordinator.appliedFontKey = fontKey
-            context.coordinator.pushChanges(from: textView)
-        }
-        // Reload only on a genuine external change; echoing our own
-        // keystrokes back through setAttributedString would fight the cursor.
-        if Self.rtfString(textView.attributedString()) != rtfBase64,
-           let restored = Self.fromRTF(rtfBase64) {
-            textView.textStorage?.setAttributedString(restored)
+            textView.refreshCheckboxImages()
             textView.normalizeCheckboxes()
+            // Push the scaled content on the next runloop tick: binding
+            // writes during a SwiftUI update pass are unreliable.
+            let coordinator = context.coordinator
+            DispatchQueue.main.async { coordinator.pushChanges(from: textView) }
         }
     }
 
@@ -360,10 +376,26 @@ private final class LinkPasteTextView: NSTextView {
     var defaultColor: NSColor = .white
     var accentColor: NSColor = .systemYellow
     var onFontSizeDelta: ((Double) -> Void)?
+    var onFontSizeReset: (() -> Void)?
     private var isNormalizing = false
 
     @objc func increaseFontSize(_ sender: Any?) { onFontSizeDelta?(1) }
     @objc func decreaseFontSize(_ sender: Any?) { onFontSizeDelta?(-1) }
+    @objc func resetFontSize(_ sender: Any?) { onFontSizeReset?() }
+
+    /// Checkbox images are sized against the body font; redraw them when it
+    /// changes so boxes and text scale together.
+    func refreshCheckboxImages() {
+        guard let storage = textStorage else { return }
+        storage.enumerateAttribute(.attachment, in: NSRange(location: 0, length: storage.length)) { value, range, _ in
+            guard let box = value as? CheckboxAttachment else { return }
+            let fresh = CheckboxAttachment.make(
+                checked: box.checked, font: defaultFont,
+                stroke: defaultColor, accent: accentColor
+            )
+            storage.addAttribute(.attachment, value: fresh, range: range)
+        }
+    }
 
     private var bodyAttributes: [NSAttributedString.Key: Any] {
         [.font: defaultFont, .foregroundColor: defaultColor,

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -1,5 +1,5 @@
+import AppKit
 import SwiftUI
-import UniformTypeIdentifiers
 
 public final class StickyNoteWidget: DashboardWidget {
     public let widgetId = "sticky-note"
@@ -35,8 +35,9 @@ public final class StickyNoteWidget: DashboardWidget {
     }
 }
 
-/// The note stores links as inline markdown — `[title](url)` — and renders
-/// them as tappable titles. No other markdown is interpreted.
+/// Always-editable rich text: links live inline as styled, clickable titles.
+/// Storage stays plain — links serialize to `[title](url)` in the config, so
+/// notes round-trip through export/import and the settings field.
 private struct StickyNoteWidgetView: View {
     let note: String
     let colorName: String
@@ -49,12 +50,7 @@ private struct StickyNoteWidgetView: View {
     @Environment(\.themeSettings) private var ts
     @State private var draft = ""
     @State private var seeded = false
-    @State private var isEditingNote = false
-    // A bare-URL paste prompts for a title; the URL and the cursor offset it
-    // will be inserted at wait here while the prompt is up.
-    @State private var pendingLinkURL: String?
-    @State private var pendingInsertOffset: Int = 0
-    @State private var linkTitle = ""
+    @State private var saveTask: Task<Void, Never>?
 
     private var primary: Color {
         switch colorName {
@@ -71,13 +67,12 @@ private struct StickyNoteWidgetView: View {
     }
 
     var body: some View {
-        Group {
-            if isEditingNote {
-                editor
-            } else {
-                display
-            }
-        }
+        RichStickyTextView(
+            markdown: $draft,
+            font: NSFont.systemFont(ofSize: 13 * ts.fontScale),
+            textColor: NSColor(Theme.text1(ts)),
+            linkColor: NSColor(primary)
+        )
         .padding(Theme.compactPadding)
         .background(primary.opacity(tintOpacity))
         .widgetCard()
@@ -87,103 +82,25 @@ private struct StickyNoteWidgetView: View {
                 seeded = true
             }
         }
-        // External edits (settings field, layout import) win over a
-        // stale on-screen draft only when they actually differ.
+        // External edits (settings field, layout import) win over a stale
+        // on-screen draft only when they actually differ.
         .onChange(of: note) { _, newValue in
             if newValue != draft { draft = newValue }
         }
+        // Debounced: saving mutates the layout document, and doing that per
+        // keystroke re-rendered every widget on the dashboard per character.
         .onChange(of: draft) { _, newValue in
-            save(newValue)
-        }
-        .alert("Name this link", isPresented: Binding(
-            get: { pendingLinkURL != nil },
-            set: { if !$0 { pendingLinkURL = nil } }
-        )) {
-            TextField("Title", text: $linkTitle)
-            Button("Add Link") { commitPendingLink() }
-            Button("Cancel", role: .cancel) { pendingLinkURL = nil }
-        } message: {
-            Text("The note shows the title; the link stays underneath.")
-        }
-    }
-
-    // MARK: - Display mode
-
-    private var display: some View {
-        ZStack(alignment: .topLeading) {
-            // Empty-area clicks enter editing; clicks on rendered text (and
-            // its links) go to the Text itself.
-            Color.white.opacity(0.001)
-                .onTapGesture { isEditingNote = true }
-            if draft.isEmpty {
-                Text("Click to write…")
-                    .font(Theme.body(ts))
-                    .foregroundStyle(Theme.text3(ts))
-            } else {
-                Text(rendered)
-                    .font(Theme.body(ts))
-                    .foregroundStyle(Theme.text1(ts))
-                    .tint(primary)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            saveTask?.cancel()
+            saveTask = Task { @MainActor in
+                try? await Task.sleep(for: .milliseconds(800))
+                guard !Task.isCancelled else { return }
+                save(newValue)
             }
         }
-        .overlay(alignment: .bottomTrailing) {
-            Button {
-                isEditingNote = true
-            } label: {
-                Image(systemName: "pencil.circle.fill")
-                    .font(.system(size: 14))
-                    .foregroundStyle(Theme.text3(ts).opacity(0.6))
-            }
-            .buttonStyle(.plain)
-            .help("Edit note")
+        .onDisappear {
+            saveTask?.cancel()
+            save(draft)
         }
-    }
-
-    private var rendered: AttributedString {
-        let options = AttributedString.MarkdownParsingOptions(
-            interpretedSyntax: .inlineOnlyPreservingWhitespace
-        )
-        return (try? AttributedString(markdown: draft, options: options))
-            ?? AttributedString(draft)
-    }
-
-    // MARK: - Edit mode
-
-    @ViewBuilder
-    private var editor: some View {
-        VStack(alignment: .trailing, spacing: 4) {
-            if #available(macOS 15.0, *) {
-                LinkingTextEditor(
-                    text: $draft,
-                    onPromptLink: { url, offset in
-                        linkTitle = ""
-                        pendingInsertOffset = offset
-                        pendingLinkURL = url
-                    }
-                )
-                .font(Theme.body(ts))
-            } else {
-                TextEditor(text: $draft)
-                    .font(Theme.body(ts))
-                    .scrollContentBackground(.hidden)
-                    .scrollIndicators(.never)
-            }
-            Button("Done") { isEditingNote = false }
-                .font(.system(size: 11, weight: .semibold, design: .rounded))
-                .keyboardShortcut(.escape, modifiers: [])
-        }
-    }
-
-    private func commitPendingLink() {
-        guard let url = pendingLinkURL else { return }
-        let title = linkTitle.trimmingCharacters(in: .whitespaces)
-        let display = title.isEmpty ? (URL(string: url)?.host ?? "link") : title
-        let insertion = "[\(display)](\(url))"
-        let offset = min(max(pendingInsertOffset, 0), draft.count)
-        let idx = draft.index(draft.startIndex, offsetBy: offset)
-        draft.insert(contentsOf: insertion, at: idx)
-        pendingLinkURL = nil
     }
 
     private func save(_ text: String) {
@@ -198,76 +115,146 @@ private struct StickyNoteWidgetView: View {
     }
 }
 
-// MARK: - Linking editor (macOS 15+)
+// MARK: - Rich text view
 
-/// TextEditor with selection tracking and paste interception: pasting a URL
-/// over selected text turns the selection into `[selection](url)`; pasting a
-/// bare URL asks the parent to prompt for a title. Everything else pastes
-/// normally.
-@available(macOS 15.0, *)
-private struct LinkingTextEditor: View {
-    @Binding var text: String
-    /// (url, character offset to insert at) — parent shows the title prompt.
-    let onPromptLink: (String, Int) -> Void
+/// NSTextView wrapper: rich in the view, `[title](url)` in storage. Pasting
+/// a URL over selected text linkifies the selection; pasting a bare URL asks
+/// for a title. Clicking a link opens it, even while editable.
+private struct RichStickyTextView: NSViewRepresentable {
+    @Binding var markdown: String
+    let font: NSFont
+    let textColor: NSColor
+    let linkColor: NSColor
 
-    @State private var selection: TextSelection?
-    @State private var keyMonitor: Any?
-    @FocusState private var focused: Bool
+    func makeNSView(context: Context) -> NSScrollView {
+        let textView = LinkPasteTextView()
+        textView.delegate = context.coordinator
+        textView.isRichText = true
+        textView.allowsUndo = true
+        textView.drawsBackground = false
+        textView.focusRingType = .none
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.textContainerInset = .zero
+        textView.autoresizingMask = [.width]
+        textView.isVerticallyResizable = true
+        textView.textContainer?.widthTracksTextView = true
+        textView.linkTextAttributes = [
+            .foregroundColor: linkColor,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+            .cursor: NSCursor.pointingHand,
+        ]
+        applyStyle(to: textView)
+        textView.textStorage?.setAttributedString(
+            Self.parse(markdown, font: font, textColor: textColor)
+        )
 
-    var body: some View {
-        TextEditor(text: $text, selection: $selection)
-            .scrollContentBackground(.hidden)
-            .scrollIndicators(.never)
-            .focused($focused)
-            .onAppear {
-                focused = true
-                // onPasteCommand never fires here: the focused NSTextView
-                // consumes Cmd+V itself. A local monitor sees the keystroke
-                // first; URL pastes are ours, everything else passes through
-                // to the text view's native paste.
-                keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-                    guard focused,
-                          event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
-                          event.charactersIgnoringModifiers?.lowercased() == "v",
-                          let pasted = NSPasteboard.general.string(forType: .string)?
-                              .trimmingCharacters(in: .whitespacesAndNewlines),
-                          isLink(pasted)
-                    else { return event }
-                    handleLinkPaste(pasted)
-                    return nil
-                }
-            }
-            .onDisappear {
-                if let keyMonitor { NSEvent.removeMonitor(keyMonitor) }
-                keyMonitor = nil
-            }
+        let scroll = NSScrollView()
+        scroll.documentView = textView
+        scroll.drawsBackground = false
+        scroll.hasVerticalScroller = false
+        scroll.verticalScrollElasticity = .none
+        return scroll
     }
 
-    private func handleLinkPaste(_ pasted: String) {
-        let selectedRange = currentRange()
-        if let range = selectedRange, !range.isEmpty {
-            // Slack-style: the selected words become the link title.
-            let title = String(text[range])
-            replace(range: range, with: "[\(title)](\(pasted))")
-        } else {
-            let idx = selectedRange?.lowerBound ?? text.endIndex
-            onPromptLink(pasted, text.distance(from: text.startIndex, to: idx))
+    func updateNSView(_ scroll: NSScrollView, context: Context) {
+        guard let textView = scroll.documentView as? LinkPasteTextView else { return }
+        applyStyle(to: textView)
+        // Only reload content on a genuine external change; echoing our own
+        // keystrokes back through setAttributedString would fight the cursor.
+        if Self.serialize(textView.attributedString()) != markdown {
+            textView.textStorage?.setAttributedString(
+                Self.parse(markdown, font: font, textColor: textColor)
+            )
         }
     }
 
-    private func currentRange() -> Range<String.Index>? {
-        guard let selection, case .selection(let range) = selection.indices else { return nil }
-        return range
+    private func applyStyle(to textView: LinkPasteTextView) {
+        textView.font = font
+        textView.textColor = textColor
+        textView.insertionPointColor = textColor
+        textView.defaultFont = font
+        textView.defaultColor = textColor
     }
 
-    private func replace(range: Range<String.Index>?, with insertion: String) {
-        // Selection indices go stale the moment the string changes; clear
-        // first so SwiftUI never resolves them against the new text.
-        selection = nil
-        if let range {
-            text.replaceSubrange(range, with: insertion)
-        } else {
-            text.append(insertion)
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: RichStickyTextView
+        init(_ parent: RichStickyTextView) { self.parent = parent }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            parent.markdown = RichStickyTextView.serialize(textView.attributedString())
+        }
+
+        func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+            let url = (link as? URL) ?? (link as? String).flatMap(URL.init(string:))
+            if let url { NSWorkspace.shared.open(url) }
+            return true
+        }
+    }
+
+    // MARK: Markdown round-trip (links only, nothing else interpreted)
+
+    static func serialize(_ attributed: NSAttributedString) -> String {
+        var out = ""
+        attributed.enumerateAttributes(in: NSRange(location: 0, length: attributed.length)) { attrs, range, _ in
+            let text = attributed.attributedSubstring(from: range).string
+            if let link = attrs[.link] {
+                let url = (link as? URL)?.absoluteString ?? (link as? String ?? "")
+                out += "[\(text)](\(url))"
+            } else {
+                out += text
+            }
+        }
+        return out
+    }
+
+    static func parse(_ markdown: String, font: NSFont, textColor: NSColor) -> NSAttributedString {
+        let plain: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: textColor]
+        let result = NSMutableAttributedString()
+        var rest = Substring(markdown)
+        let pattern = /\[([^\]]+)\]\(([^)\s]+)\)/
+        while let match = rest.firstMatch(of: pattern) {
+            result.append(NSAttributedString(string: String(rest[rest.startIndex..<match.range.lowerBound]), attributes: plain))
+            var linkAttrs = plain
+            linkAttrs[.link] = String(match.2)
+            result.append(NSAttributedString(string: String(match.1), attributes: linkAttrs))
+            rest = rest[match.range.upperBound...]
+        }
+        result.append(NSAttributedString(string: String(rest), attributes: plain))
+        return result
+    }
+}
+
+/// The paste override that makes URLs become links instead of sprawling text.
+private final class LinkPasteTextView: NSTextView {
+    var defaultFont: NSFont = .systemFont(ofSize: 13)
+    var defaultColor: NSColor = .white
+
+    override func paste(_ sender: Any?) {
+        guard let pasted = NSPasteboard.general.string(forType: .string)?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            isLink(pasted)
+        else {
+            super.paste(sender)
+            return
+        }
+
+        let range = selectedRange()
+        if range.length > 0 {
+            // Slack-style: the selected words become the link title.
+            guard shouldChangeText(in: range, replacementString: nil) else { return }
+            textStorage?.addAttribute(.link, value: pasted, range: range)
+            didChangeText()
+        } else if let title = Self.promptForTitle(defaultTitle: URL(string: pasted)?.host ?? "link") {
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: defaultFont, .foregroundColor: defaultColor, .link: pasted,
+            ]
+            insertText(NSAttributedString(string: title, attributes: attrs), replacementRange: range)
+            // Continued typing must not extend the link.
+            typingAttributes[.link] = nil
         }
     }
 
@@ -275,5 +262,20 @@ private struct LinkingTextEditor: View {
         guard !s.contains(" "), let url = URL(string: s),
               let scheme = url.scheme?.lowercased() else { return false }
         return (scheme == "http" || scheme == "https") && url.host != nil
+    }
+
+    private static func promptForTitle(defaultTitle: String) -> String? {
+        let alert = NSAlert()
+        alert.messageText = "Name this link"
+        alert.informativeText = "The note shows the title; the link stays underneath."
+        alert.addButton(withTitle: "Add Link")
+        alert.addButton(withTitle: "Cancel")
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        field.placeholderString = defaultTitle
+        alert.accessoryView = field
+        alert.window.initialFirstResponder = field
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        let typed = field.stringValue.trimmingCharacters(in: .whitespaces)
+        return typed.isEmpty ? defaultTitle : typed
     }
 }

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -563,6 +563,7 @@ private final class LinkPasteTextView: NSTextView {
             idx -= 1
         }
         applyParagraphSpacing()
+        renumberOrderedLists()
     }
 
     /// Every paragraph gets its rhythm: heading-sized first characters get
@@ -597,6 +598,50 @@ private final class LinkPasteTextView: NSTextView {
                 level: indentLevel(of: existing, isList: isList)
             )
             storage.addAttribute(.paragraphStyle, value: style, range: paragraph)
+            location = paragraph.location + paragraph.length
+        }
+    }
+
+    /// Numbered items in a contiguous list block stay sequential per indent
+    /// level: each one follows the previous number at its level (bullets and
+    /// checkboxes between them don't break the count), and any non-list
+    /// line — blank or plain text — ends the block and resets numbering.
+    /// Runs on every change, so inserting, deleting or converting an item
+    /// renumbers the rest of its list. The block's first number is kept
+    /// as typed, so lists may start anywhere.
+    private func renumberOrderedLists() {
+        guard let storage = textStorage, storage.length > 0 else { return }
+        var counters: [Int: Int] = [:]
+        var location = 0
+        while location < (storage.string as NSString).length {
+            let ns = storage.string as NSString
+            let paragraph = ns.lineRange(for: NSRange(location: location, length: 0))
+            var line = ns.substring(with: paragraph)
+            if line.hasSuffix("\n") { line.removeLast() }
+            if markerLength(of: line) == 0 {
+                counters.removeAll()
+                location = paragraph.location + paragraph.length
+                continue
+            }
+            if let tab = line.firstIndex(of: "\t"), line[..<tab].hasSuffix("."),
+               let n = Int(line[..<tab].dropLast()) {
+                let existing = storage.attribute(.paragraphStyle, at: paragraph.location, effectiveRange: nil) as? NSParagraphStyle
+                let level = indentLevel(of: existing, isList: true)
+                counters = counters.filter { $0.key <= level }
+                let expected = counters[level].map { $0 + 1 } ?? n
+                counters[level] = expected
+                if n != expected {
+                    let headLength = (String(line[..<tab]) as NSString).length
+                    storage.replaceCharacters(
+                        in: NSRange(location: paragraph.location, length: headLength),
+                        with: "\(expected)."
+                    )
+                    let fresh = (storage.string as NSString)
+                        .lineRange(for: NSRange(location: paragraph.location, length: 0))
+                    location = fresh.location + fresh.length
+                    continue
+                }
+            }
             location = paragraph.location + paragraph.length
         }
     }

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -620,6 +620,18 @@ private final class LinkPasteTextView: NSTextView {
         return s
     }
 
+    /// The flipped replacement for an existing box, carrying over the
+    /// character's current paragraph style — a bare checkboxOnly() has
+    /// none, and normalization would read that as indent level 0,
+    /// outdenting the line on every toggle.
+    private func toggledBox(_ box: CheckboxAttachment, at location: Int) -> NSAttributedString {
+        let s = NSMutableAttributedString(attributedString: checkboxOnly(checked: !box.checked))
+        if let style = textStorage?.attribute(.paragraphStyle, at: location, effectiveRange: nil) {
+            s.addAttribute(.paragraphStyle, value: style, range: NSRange(location: 0, length: s.length))
+        }
+        return s
+    }
+
     private func checkboxOnly(checked: Bool) -> NSAttributedString {
         let attachment = CheckboxAttachment.make(
             checked: checked, font: defaultFont,
@@ -1022,7 +1034,7 @@ private final class LinkPasteTextView: NSTextView {
             if let box = textStorage?.attribute(.attachment, at: candidate, effectiveRange: nil) as? CheckboxAttachment {
                 let range = NSRange(location: candidate, length: 1)
                 guard shouldChangeText(in: range, replacementString: nil) else { break }
-                textStorage?.replaceCharacters(in: range, with: checkboxOnly(checked: !box.checked))
+                textStorage?.replaceCharacters(in: range, with: toggledBox(box, at: candidate))
                 didChangeText()
                 return
             }
@@ -1044,7 +1056,7 @@ private final class LinkPasteTextView: NSTextView {
                let box = storage.attribute(.attachment, at: paragraph.location, effectiveRange: nil) as? CheckboxAttachment {
                 let range = NSRange(location: paragraph.location, length: 1)
                 if shouldChangeText(in: range, replacementString: nil) {
-                    storage.replaceCharacters(in: range, with: checkboxOnly(checked: !box.checked))
+                    storage.replaceCharacters(in: range, with: toggledBox(box, at: paragraph.location))
                     didChangeText()
                 }
             }

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -404,37 +404,89 @@ private final class LinkPasteTextView: NSTextView {
 
     /// Shared rhythm for body, bullet and checkbox lines.
     private var bodyParagraph: NSParagraphStyle {
-        let p = NSMutableParagraphStyle()
-        p.paragraphSpacing = defaultFont.pointSize * 0.22
-        return p
+        paragraphStyle(isHeading: false, isList: false, isBullet: false, level: 0)
     }
 
-    /// Column where list text begins; markers sit flush left before a tab.
-    private var listTextIndent: CGFloat { (defaultFont.pointSize * 2.1).rounded() }
+    /// Column where list text begins; markers sit before a tab.
+    private var listTextIndent: CGFloat { (defaultFont.pointSize * 1.8).rounded() }
 
-    /// List lines: marker, tab, text — one shared text column for bullets,
-    /// checkboxes and numerals, with wrapped lines hanging under the text.
+    /// One Tab/Shift-Tab step — the width of the list column, so nested
+    /// list text lands exactly one column further in.
+    private var indentStep: CGFloat { listTextIndent }
+    private let maxIndentLevel = 6
+
+    /// Narrow bullets get inset so they sit centered under the wider
+    /// checkbox column instead of hugging the left edge.
+    private var bulletInset: CGFloat {
+        let bulletWidth = ("•" as NSString).size(withAttributes: [.font: defaultFont]).width
+        return max(0, ((defaultFont.pointSize * 1.2 - bulletWidth) / 2).rounded())
+    }
+
     private var listParagraph: NSParagraphStyle {
-        let p = NSMutableParagraphStyle()
-        p.paragraphSpacing = defaultFont.pointSize * 0.22
-        p.tabStops = [NSTextTab(textAlignment: .left, location: listTextIndent)]
-        p.defaultTabInterval = listTextIndent
-        p.headIndent = listTextIndent
-        return p
-    }
-
-    private var listAttributes: [NSAttributedString.Key: Any] {
-        var a = bodyAttributes
-        a[.paragraphStyle] = listParagraph
-        return a
+        paragraphStyle(isHeading: false, isList: true, isBullet: false, level: 0)
     }
 
     /// Headings breathe a little more, especially above.
     private var headingParagraph: NSParagraphStyle {
+        paragraphStyle(isHeading: true, isList: false, isBullet: false, level: 0)
+    }
+
+    /// Single source of paragraph geometry: spacing rhythm per line kind
+    /// plus the Tab/Shift-Tab indent level. List lines keep one shared
+    /// text column (marker, tab, text) shifted right per level, with
+    /// wrapped lines hanging under the text.
+    private func paragraphStyle(isHeading: Bool, isList: Bool, isBullet: Bool, level: Int) -> NSParagraphStyle {
         let p = NSMutableParagraphStyle()
-        p.paragraphSpacing = defaultFont.pointSize * 0.3
-        p.paragraphSpacingBefore = defaultFont.pointSize * 0.5
+        let indent = CGFloat(level) * indentStep
+        if isHeading {
+            p.paragraphSpacing = defaultFont.pointSize * 0.3
+            p.paragraphSpacingBefore = defaultFont.pointSize * 0.5
+            p.firstLineHeadIndent = indent
+            p.headIndent = indent
+        } else if isList {
+            p.paragraphSpacing = defaultFont.pointSize * 0.22
+            p.firstLineHeadIndent = indent + (isBullet ? bulletInset : 0)
+            p.tabStops = [NSTextTab(textAlignment: .left, location: indent + listTextIndent)]
+            p.defaultTabInterval = listTextIndent
+            p.headIndent = indent + listTextIndent
+        } else {
+            p.paragraphSpacing = defaultFont.pointSize * 0.22
+            p.firstLineHeadIndent = indent
+            p.headIndent = indent
+        }
         return p
+    }
+
+    /// The indent level is never stored separately — it is recovered from
+    /// the geometry of the line's current style, so it survives saves,
+    /// loads and every re-normalization pass.
+    private func indentLevel(of style: NSParagraphStyle?, isList: Bool) -> Int {
+        guard let style else { return 0 }
+        let base = isList
+            ? (style.tabStops.first?.location ?? listTextIndent) - listTextIndent
+            : style.firstLineHeadIndent
+        return max(0, min(maxIndentLevel, Int((base / indentStep).rounded())))
+    }
+
+    /// Leading marker of a line — "•", a drawn checkbox, or "N." — with its
+    /// trailing tab. 0 when the line is not a list item.
+    private func markerLength(of line: String) -> Int {
+        if line.hasPrefix("•\t") || line.hasPrefix("\u{FFFC}\t") { return 2 }
+        guard let tab = line.firstIndex(of: "\t") else { return 0 }
+        let head = line[..<tab]
+        guard head.hasSuffix("."), head.count <= 6, !head.dropLast().isEmpty,
+              Int(head.dropLast()) != nil else { return 0 }
+        return (String(line[...tab]) as NSString).length
+    }
+
+    private var listAttributes: [NSAttributedString.Key: Any] {
+        listAttributes(level: 0)
+    }
+
+    private func listAttributes(level: Int) -> [NSAttributedString.Key: Any] {
+        var a = bodyAttributes
+        a[.paragraphStyle] = paragraphStyle(isHeading: false, isList: true, isBullet: false, level: level)
+        return a
     }
 
     override func didChangeText() {
@@ -473,10 +525,13 @@ private final class LinkPasteTextView: NSTextView {
         typingAttributes = bodyAttributes
     }
 
-    /// One drawn checkbox (attachment) plus its following no-break space.
-    private func checkboxMarker(checked: Bool) -> NSAttributedString {
+    /// One drawn checkbox (attachment) plus its following tab.
+    private func checkboxMarker(checked: Bool, level: Int = 0) -> NSAttributedString {
         let s = NSMutableAttributedString(attributedString: checkboxOnly(checked: checked))
-        s.append(NSAttributedString(string: "\t", attributes: listAttributes))
+        s.append(NSAttributedString(string: "\t", attributes: listAttributes(level: level)))
+        s.addAttribute(.paragraphStyle,
+                       value: paragraphStyle(isHeading: false, isList: true, isBullet: false, level: level),
+                       range: NSRange(location: 0, length: s.length))
         return s
     }
 
@@ -532,14 +587,15 @@ private final class LinkPasteTextView: NSTextView {
                 continue
             }
 
-            let isList = line.hasPrefix("•\t") || line.hasPrefix("\u{FFFC}\t") || {
-                guard let tab = line.firstIndex(of: "\t") else { return false }
-                let head = line[..<tab]
-                return head.hasSuffix(".") && Int(head.dropLast()) != nil && !head.dropLast().isEmpty
-            }()
+            let isList = markerLength(of: line) > 0
             let firstFont = storage.attribute(.font, at: paragraph.location, effectiveRange: nil) as? NSFont
-            let isHeading = (firstFont?.pointSize ?? 0) > headingThreshold
-            let style = isHeading ? headingParagraph : (isList ? listParagraph : bodyParagraph)
+            let existing = storage.attribute(.paragraphStyle, at: paragraph.location, effectiveRange: nil) as? NSParagraphStyle
+            let style = paragraphStyle(
+                isHeading: !isList && (firstFont?.pointSize ?? 0) > headingThreshold,
+                isList: isList,
+                isBullet: line.hasPrefix("•\t"),
+                level: indentLevel(of: existing, isList: isList)
+            )
             storage.addAttribute(.paragraphStyle, value: style, range: paragraph)
             location = paragraph.location + paragraph.length
         }
@@ -591,42 +647,96 @@ private final class LinkPasteTextView: NSTextView {
         super.insertText(insertString, replacementRange: replacementRange)
     }
 
-    /// "- " → bullet, "- [ ] " → checkbox, "# "/"## "/"### " → heading.
-    /// Called when a space is typed; returns true when the space is consumed.
+    /// Tab and Shift-Tab indent and unindent the line the caret is on (or
+    /// every line the selection touches), wherever the caret sits in it.
+    override func insertTab(_ sender: Any?) { changeIndent(by: 1) }
+    override func insertBacktab(_ sender: Any?) { changeIndent(by: -1) }
+
+    private func changeIndent(by delta: Int) {
+        guard let storage = textStorage else { return }
+        let ns = storage.string as NSString
+        let lines = ns.lineRange(for: selectedRange())
+        // The empty last line has no characters to restyle; move the pen.
+        guard lines.length > 0 else {
+            let existing = typingAttributes[.paragraphStyle] as? NSParagraphStyle
+            let level = max(0, min(maxIndentLevel, indentLevel(of: existing, isList: false) + delta))
+            typingAttributes[.paragraphStyle] = paragraphStyle(isHeading: false, isList: false, isBullet: false, level: level)
+            return
+        }
+        guard shouldChangeText(in: lines, replacementString: nil) else { return }
+        var location = lines.location
+        while location < NSMaxRange(lines) {
+            let paragraph = ns.lineRange(for: NSRange(location: location, length: 0))
+            var line = ns.substring(with: paragraph)
+            if line.hasSuffix("\n") { line.removeLast() }
+            let isList = markerLength(of: line) > 0
+            let firstFont = storage.attribute(.font, at: paragraph.location, effectiveRange: nil) as? NSFont
+            let existing = storage.attribute(.paragraphStyle, at: paragraph.location, effectiveRange: nil) as? NSParagraphStyle
+            let level = max(0, min(maxIndentLevel, indentLevel(of: existing, isList: isList) + delta))
+            storage.addAttribute(.paragraphStyle, value: paragraphStyle(
+                isHeading: !isList && (firstFont?.pointSize ?? 0) > defaultFont.pointSize * 1.1,
+                isList: isList,
+                isBullet: line.hasPrefix("•\t"),
+                level: level
+            ), range: paragraph)
+            location = paragraph.location + paragraph.length
+        }
+        didChangeText()
+    }
+
+    /// Space-triggered conversions: "[ ]" forms → checkbox, "#" → heading,
+    /// "N." → numbered item. On a line that is already a list item the
+    /// typed marker replaces the existing one, so any list type turns into
+    /// any other by typing its trigger right after the marker.
     private func convertLinePrefix() -> Bool {
         let ns = string as NSString
         let loc = selectedRange().location
         let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
         guard loc >= lineRange.location else { return false }
-        let prefixRange = NSRange(location: lineRange.location, length: loc - lineRange.location)
-        let prefix = ns.substring(with: prefixRange)
+        var fullLine = ns.substring(with: lineRange)
+        if fullLine.hasSuffix("\n") { fullLine.removeLast() }
+        let markerLen = markerLength(of: fullLine)
+        guard loc - lineRange.location >= markerLen else { return false }
+        let typed = ns.substring(with: NSRange(
+            location: lineRange.location + markerLen,
+            length: loc - lineRange.location - markerLen
+        ))
+        // Replacements swallow the existing marker along with the trigger.
+        let fullRange = NSRange(location: lineRange.location, length: loc - lineRange.location)
+        let existing = textStorage?.attribute(.paragraphStyle, at: lineRange.location, effectiveRange: nil) as? NSParagraphStyle
+        let level = indentLevel(of: existing, isList: markerLen > 0)
 
-        switch prefix {
-        // "- " already became a bullet by the time "[ ]" is typed, so the
-        // checkbox forms chain off the bullet. Conversion waits for the
-        // CLOSING bracket — converting at "[" would make "[x]" untypeable.
-        case "- [ ]", "- []", "•\u{00A0}[ ]", "•\u{00A0}[]", "•\t[ ]", "•\t[]":
-            replace(prefixRange, with: checkboxMarker(checked: false))
+        // Checkbox conversion waits for the CLOSING bracket — converting at
+        // "[" would make "[x]" untypeable. Bare bracket forms need an
+        // existing marker; on plain text the leading "- " is required.
+        let boxForms: [String: Bool] = ["[ ]": false, "[]": false,
+                                        "[x]": true, "[X]": true, "[ x]": true, "[ X]": true]
+        let boxTyped = typed.hasPrefix("- ") ? String(typed.dropFirst(2)) : typed
+        if let checked = boxForms[boxTyped], typed.hasPrefix("- ") || markerLen > 0 {
+            replace(fullRange, with: checkboxMarker(checked: checked, level: level))
             return true
-        case "- [x]", "- [X]", "•\u{00A0}[x]", "•\u{00A0}[X]",
-             "•\u{00A0}[ x]", "•\u{00A0}[ X]", "•\t[x]", "•\t[X]", "•\t[ x]", "•\t[ X]":
-            replace(prefixRange, with: checkboxMarker(checked: true))
-            return true
-        case "#", "##", "###":
-            replace(prefixRange, with: NSAttributedString(string: ""))
+        }
+        if typed == "#" || typed == "##" || typed == "###" {
+            replace(fullRange, with: NSAttributedString(string: ""))
             var attrs = bodyAttributes
-            attrs[.font] = headingFont(prefix.count)
+            attrs[.font] = headingFont(typed.count)
             attrs[.paragraphStyle] = headingParagraph
             typingAttributes = attrs
             return true
-        default:
-            // Ordered list: any number followed by "." and a space.
-            if prefix.hasSuffix("."), prefix.count <= 5, Int(prefix.dropLast()) != nil {
-                replace(prefixRange, with: NSAttributedString(string: prefix + "\t", attributes: listAttributes))
-                return true
-            }
-            return false
         }
+        // "- "/"* " on a plain line stays deferred (convertDashIfPending);
+        // on an existing list item it switches the item to a bullet now.
+        if typed == "-" || typed == "*", markerLen > 0 {
+            replace(fullRange, with: NSAttributedString(string: "•\t", attributes: listAttributes(level: level)))
+            return true
+        }
+        // Ordered list: any number followed by "." and a space.
+        if typed.hasSuffix("."), typed.count <= 5, !typed.dropLast().isEmpty,
+           Int(typed.dropLast()) != nil {
+            replace(fullRange, with: NSAttributedString(string: typed + "\t", attributes: listAttributes(level: level)))
+            return true
+        }
+        return false
     }
 
     /// Pressing return inside a link's text opens the link. Both neighbors
@@ -657,7 +767,9 @@ private final class LinkPasteTextView: NSTextView {
         let prefixRange = NSRange(location: lineRange.location, length: 2)
         let prefix = ns.substring(with: prefixRange)
         guard prefix == "- " || prefix == "* " else { return }
-        replace(prefixRange, with: NSAttributedString(string: "•\t", attributes: listAttributes))
+        let existing = textStorage?.attribute(.paragraphStyle, at: lineRange.location, effectiveRange: nil) as? NSParagraphStyle
+        let level = indentLevel(of: existing, isList: false)
+        replace(prefixRange, with: NSAttributedString(string: "•\t", attributes: listAttributes(level: level)))
     }
 
     /// Typing "-" or "*" right after a fresh checkbox marker switches the
@@ -673,7 +785,9 @@ private final class LinkPasteTextView: NSTextView {
               storage.attribute(.attachment, at: lineRange.location, effectiveRange: nil) is CheckboxAttachment
         else { return false }
         let markerRange = NSRange(location: lineRange.location, length: 2)
-        replace(markerRange, with: NSAttributedString(string: "•\t", attributes: listAttributes))
+        let existing = storage.attribute(.paragraphStyle, at: lineRange.location, effectiveRange: nil) as? NSParagraphStyle
+        let level = indentLevel(of: existing, isList: true)
+        replace(markerRange, with: NSAttributedString(string: "•\t", attributes: listAttributes(level: level)))
         return true
     }
 
@@ -727,20 +841,25 @@ private final class LinkPasteTextView: NSTextView {
         func hasContent(after marker: String) -> Bool {
             !line.dropFirst(marker.count).trimmingCharacters(in: .whitespaces).isEmpty
         }
+        // The new item continues at the same indent level as the current one.
+        let existing = lineRange.length > 0
+            ? textStorage?.attribute(.paragraphStyle, at: lineRange.location, effectiveRange: nil) as? NSParagraphStyle
+            : nil
+        let level = indentLevel(of: existing, isList: true)
         for sep in ["\t", "\u{00A0}"] {
             if line.hasPrefix("•" + sep) {
                 return hasContent(after: "•" + sep)
-                    ? NSAttributedString(string: "•\t", attributes: listAttributes) : nil
+                    ? NSAttributedString(string: "•\t", attributes: listAttributes(level: level)) : nil
             }
             if line.hasPrefix("\u{FFFC}" + sep) {
-                return hasContent(after: "\u{FFFC}" + sep) ? checkboxMarker(checked: false) : nil
+                return hasContent(after: "\u{FFFC}" + sep) ? checkboxMarker(checked: false, level: level) : nil
             }
         }
         // Numbered: "N.<tab>" continues as "N+1.<tab>".
         if let tab = line.firstIndex(of: "\t"), line[..<tab].hasSuffix("."),
            let n = Int(line[..<tab].dropLast()) {
             return hasContent(after: String(line[...tab]))
-                ? NSAttributedString(string: "\(n + 1).\t", attributes: listAttributes) : nil
+                ? NSAttributedString(string: "\(n + 1).\t", attributes: listAttributes(level: level)) : nil
         }
         return nil
     }

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -356,6 +356,33 @@ private final class LinkPasteTextView: NSTextView {
         isNormalizing = true
         normalizeCheckboxes()
         isNormalizing = false
+        // Deleting everything must also clear the invisible pen: with no
+        // neighbor to inherit from, stale heading attributes would make an
+        // emptied note type headings forever.
+        if textStorage?.length == 0 {
+            typingAttributes = bodyAttributes
+        }
+    }
+
+    /// Format > Body Text: strips heading size, bold/italic, underline and
+    /// strikethrough from the selection (or the current line), keeping links.
+    @objc func resetToBodyText(_ sender: Any?) {
+        guard let storage = textStorage else { return }
+        let ns = string as NSString
+        var range = selectedRange()
+        if range.length == 0 {
+            range = ns.lineRange(for: NSRange(location: range.location, length: 0))
+        }
+        guard range.length > 0 else {
+            typingAttributes = bodyAttributes
+            return
+        }
+        guard shouldChangeText(in: range, replacementString: nil) else { return }
+        storage.addAttribute(.font, value: defaultFont, range: range)
+        storage.removeAttribute(.strikethroughStyle, range: range)
+        storage.removeAttribute(.underlineStyle, range: range)
+        didChangeText()
+        typingAttributes = bodyAttributes
     }
 
     /// One drawn checkbox (attachment) plus its following no-break space.

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -347,7 +347,23 @@ private final class LinkPasteTextView: NSTextView {
     private var isNormalizing = false
 
     private var bodyAttributes: [NSAttributedString.Key: Any] {
-        [.font: defaultFont, .foregroundColor: defaultColor]
+        [.font: defaultFont, .foregroundColor: defaultColor,
+         .paragraphStyle: bodyParagraph]
+    }
+
+    /// Shared rhythm for body, bullet and checkbox lines.
+    private var bodyParagraph: NSParagraphStyle {
+        let p = NSMutableParagraphStyle()
+        p.paragraphSpacing = defaultFont.pointSize * 0.22
+        return p
+    }
+
+    /// Headings breathe a little more, especially above.
+    private var headingParagraph: NSParagraphStyle {
+        let p = NSMutableParagraphStyle()
+        p.paragraphSpacing = defaultFont.pointSize * 0.3
+        p.paragraphSpacingBefore = defaultFont.pointSize * 0.5
+        return p
     }
 
     override func didChangeText() {
@@ -379,6 +395,7 @@ private final class LinkPasteTextView: NSTextView {
         }
         guard shouldChangeText(in: range, replacementString: nil) else { return }
         storage.addAttribute(.font, value: defaultFont, range: range)
+        storage.addAttribute(.paragraphStyle, value: bodyParagraph, range: range)
         storage.removeAttribute(.strikethroughStyle, range: range)
         storage.removeAttribute(.underlineStyle, range: range)
         didChangeText()
@@ -418,6 +435,24 @@ private final class LinkPasteTextView: NSTextView {
                 storage.replaceCharacters(in: range, with: checkboxOnly(checked: ch == "☑"))
             }
             idx -= 1
+        }
+        applyParagraphSpacing()
+    }
+
+    /// Every paragraph gets its rhythm: heading-sized first characters get
+    /// the heading spacing, everything else the body spacing. Runs as part
+    /// of normalization so loaded and pasted content is covered too.
+    private func applyParagraphSpacing() {
+        guard let storage = textStorage, storage.length > 0 else { return }
+        let ns = storage.string as NSString
+        let headingThreshold = defaultFont.pointSize * 1.1
+        var location = 0
+        while location < ns.length {
+            let paragraph = ns.lineRange(for: NSRange(location: location, length: 0))
+            let firstFont = storage.attribute(.font, at: paragraph.location, effectiveRange: nil) as? NSFont
+            let style = (firstFont?.pointSize ?? 0) > headingThreshold ? headingParagraph : bodyParagraph
+            storage.addAttribute(.paragraphStyle, value: style, range: paragraph)
+            location = paragraph.location + paragraph.length
         }
     }
 
@@ -489,6 +524,7 @@ private final class LinkPasteTextView: NSTextView {
             replace(prefixRange, with: NSAttributedString(string: ""))
             var attrs = bodyAttributes
             attrs[.font] = headingFont(prefix.count)
+            attrs[.paragraphStyle] = headingParagraph
             typingAttributes = attrs
             return true
         default:

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+public final class StickyNoteWidget: DashboardWidget {
+    public let widgetId = "sticky-note"
+    public let displayName = "Sticky Note"
+    public let description = "A free-form note, edited in place and saved with the layout"
+    public let iconName = "note.text"
+    public let category: WidgetCategory = .info
+    public let requiredServices: Set<ServiceKey> = []
+    public let supportedSizes = WidgetSizeRange(min: .size(2, 1), max: .size(8, 6))
+    public let defaultSize = WidgetSize.size(3, 2)
+
+    public let configSchema: [ConfigSchemaEntry] = [
+        ConfigSchemaEntry(key: "note", label: "Note", type: .text, defaultValue: .string("")),
+    ]
+    public let defaultColors = WidgetColors(primary: .yellow)
+
+    public init() {}
+
+    @MainActor
+    public func body(size: WidgetSize, config: WidgetConfig) -> any View {
+        StickyNoteWidgetView(
+            note: config.string("note"),
+            pageId: config.string("_pageId"),
+            instanceId: config.string("_instanceId"),
+            baseConfig: config
+        )
+    }
+}
+
+private struct StickyNoteWidgetView: View {
+    let note: String
+    let pageId: String
+    let instanceId: String
+    let baseConfig: WidgetConfig
+
+    @EnvironmentObject private var layoutEngine: LayoutEngine
+    @Environment(\.themeSettings) private var ts
+    @State private var draft = ""
+    @State private var seeded = false
+
+    private var primary: Color { Theme.widgetPrimary("sticky-note", ts: ts, default: .yellow) }
+
+    var body: some View {
+        TextEditor(text: $draft)
+            .font(Theme.body(ts))
+            .foregroundStyle(Theme.text1(ts))
+            .scrollContentBackground(.hidden)
+            .scrollIndicators(.never)
+            .padding(Theme.compactPadding)
+            .background(primary.opacity(0.10))
+            .widgetCard()
+            .onAppear {
+                if !seeded {
+                    draft = note
+                    seeded = true
+                }
+            }
+            // External edits (settings field, layout import) win over a
+            // stale on-screen draft only when they actually differ.
+            .onChange(of: note) { _, newValue in
+                if newValue != draft { draft = newValue }
+            }
+            .onChange(of: draft) { _, newValue in
+                save(newValue)
+            }
+    }
+
+    private func save(_ text: String) {
+        guard !instanceId.isEmpty, text != note else { return }
+        // Strip the injected identity keys: they describe the render pass,
+        // not the widget's persistent state.
+        var config = baseConfig
+        config["note"] = .string(text)
+        config["_pageId"] = nil
+        config["_instanceId"] = nil
+        layoutEngine.updateWidgetConfig(pageId: pageId, instanceId: instanceId, config: config)
+    }
+}

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -490,17 +490,22 @@ private final class LinkPasteTextView: NSTextView {
     }
 
     override func didChangeText() {
-        super.didChangeText()
-        guard !isNormalizing else { return }
-        isNormalizing = true
-        normalizeCheckboxes()
-        isNormalizing = false
-        // Deleting everything must also clear the invisible pen: with no
-        // neighbor to inherit from, stale heading attributes would make an
-        // emptied note type headings forever.
-        if textStorage?.length == 0 {
-            typingAttributes = bodyAttributes
+        // Normalize BEFORE notifying: renumbering can rewrite characters,
+        // and observers (the SwiftUI binding) must capture the final text.
+        // A stale capture makes the next render reload the view from old
+        // RTF, throwing the caret to the end of the note.
+        if !isNormalizing {
+            isNormalizing = true
+            normalizeCheckboxes()
+            isNormalizing = false
+            // Deleting everything must also clear the invisible pen: with no
+            // neighbor to inherit from, stale heading attributes would make
+            // an emptied note type headings forever.
+            if textStorage?.length == 0 {
+                typingAttributes = bodyAttributes
+            }
         }
+        super.didChangeText()
     }
 
     /// Format > Body Text: strips heading size, bold/italic, underline and

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -370,6 +370,9 @@ private final class LinkPasteTextView: NSTextView {
         if str == " ", convertLinePrefix() { return }
 
         if str == "\n" {
+            // Enter on an empty bullet/checkbox line ends the list: the
+            // marker disappears instead of a new one being created.
+            if removeBareListMarker() { return }
             if convertHorizontalRule() { return }
             let continuation = listContinuation()
             super.insertText(insertString, replacementRange: replacementRange)
@@ -381,6 +384,10 @@ private final class LinkPasteTextView: NSTextView {
             return
         }
 
+        // The bullet waits for the first character after "- ": converting on
+        // the space itself created a confusing interstitial state and stole
+        // the "[" that starts a checkbox.
+        if str.count == 1, str != "[" { convertDashIfPending() }
         super.insertText(insertString, replacementRange: replacementRange)
     }
 
@@ -395,9 +402,6 @@ private final class LinkPasteTextView: NSTextView {
         let prefix = ns.substring(with: prefixRange)
 
         switch prefix {
-        case "-":
-            replace(prefixRange, with: NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes))
-            return true
         // "- " already became a bullet by the time "[ ]" is typed, so the
         // checkbox forms chain off the bullet. Conversion waits for the
         // CLOSING bracket — converting at "[" would make "[x]" untypeable.
@@ -417,6 +421,35 @@ private final class LinkPasteTextView: NSTextView {
         default:
             return false
         }
+    }
+
+    /// A line whose full content is "- " becomes a bullet the moment a
+    /// non-bracket character follows — no interstitial bullet while a
+    /// checkbox is being typed.
+    private func convertDashIfPending() {
+        let ns = string as NSString
+        let loc = selectedRange().location
+        let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
+        guard loc - lineRange.location == 2 else { return }
+        let prefixRange = NSRange(location: lineRange.location, length: 2)
+        guard ns.substring(with: prefixRange) == "- " else { return }
+        replace(prefixRange, with: NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes))
+    }
+
+    /// Pressing return on a line that is nothing but a list marker deletes
+    /// the marker (ending the list) rather than continuing it.
+    private func removeBareListMarker() -> Bool {
+        let ns = string as NSString
+        let loc = selectedRange().location
+        let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
+        var content = ns.substring(with: lineRange)
+        if content.hasSuffix("\n") { content.removeLast() }
+        let markers = ["•\u{00A0}", "☐\u{00A0}", "☑\u{00A0}", "•", "☐", "☑"]
+        guard markers.contains(content) else { return false }
+        let deleteRange = NSRange(location: lineRange.location, length: (content as NSString).length)
+        replace(deleteRange, with: NSAttributedString(string: ""))
+        typingAttributes = bodyAttributes
+        return true
     }
 
     /// A line reading exactly "---" becomes a dim horizontal rule on return.

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -341,16 +341,28 @@ private final class LinkPasteTextView: NSTextView {
     func applyCheckboxCursors() {
         guard let storage = textStorage else { return }
         let ns = storage.string as NSString
-        // Twice the body size: the glyph is a tap target, not a character.
-        let size = defaultFont.pointSize * 2
+        // Enlarged as a tap target — but the line height is clamped to the
+        // body's, because the caret spans the line: an unclamped 2x glyph
+        // made the insertion cursor giant. The box's ink is small within its
+        // em square, so 1.5x fits a body-height line.
+        let size = defaultFont.pointSize * 1.5
         let glyphFont = NSFont(descriptor: defaultFont.fontDescriptor, size: size)
             ?? NSFont.systemFont(ofSize: size)
+        let bodyLine = defaultFont.ascender + abs(defaultFont.descender) + defaultFont.leading
+        let para = NSMutableParagraphStyle()
+        para.minimumLineHeight = bodyLine
+        para.maximumLineHeight = bodyLine * 1.12
         var idx = 0
         while idx < ns.length {
             let ch = ns.substring(with: NSRange(location: idx, length: 1))
             if ch == "☐" || ch == "☑" {
                 storage.addAttributes(
-                    [.cursor: NSCursor.pointingHand, .font: glyphFont],
+                    [
+                        .cursor: NSCursor.pointingHand,
+                        .font: glyphFont,
+                        .paragraphStyle: para,
+                        .baselineOffset: -(size - defaultFont.pointSize) * 0.15,
+                    ],
                     range: NSRange(location: idx, length: 1)
                 )
             }

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -15,11 +15,11 @@ public final class StickyNoteWidget: DashboardWidget {
         ConfigSchemaEntry(key: "note", label: "Note", type: .text, defaultValue: .string("")),
         ConfigSchemaEntry(key: "color", label: "Color", type: .picker, defaultValue: .string("yellow"),
                           options: ["yellow", "orange", "pink", "red", "green", "mint", "blue", "purple", "gray"]),
-        ConfigSchemaEntry(key: "opacity", label: "Opacity", type: .slider, defaultValue: .double(0.12),
+        ConfigSchemaEntry(key: "opacity", label: "Opacity", type: .slider, defaultValue: .double(0.5),
                           minValue: 0.0, maxValue: 1.0, step: 0.05),
-        ConfigSchemaEntry(key: "font", label: "Font", type: .picker, defaultValue: .string("system"),
+        ConfigSchemaEntry(key: "font", label: "Font", type: .picker, defaultValue: .string("mono"),
                           options: ["system", "rounded", "serif", "mono", "marker", "noteworthy"]),
-        ConfigSchemaEntry(key: "fontSize", label: "Font Size", type: .slider, defaultValue: .double(13),
+        ConfigSchemaEntry(key: "fontSize", label: "Font Size", type: .slider, defaultValue: .double(18),
                           minValue: 10, maxValue: 24, step: 1),
     ]
     public let defaultColors = WidgetColors(primary: .yellow)
@@ -32,9 +32,9 @@ public final class StickyNoteWidget: DashboardWidget {
             note: config.string("note"),
             rtf: config.string("rtf"),
             colorName: config.string("color", default: "yellow"),
-            tintOpacity: config.double("opacity", default: 0.12),
-            fontFamily: config.string("font", default: "system"),
-            fontSize: config.double("fontSize", default: 13),
+            tintOpacity: config.double("opacity", default: 0.5),
+            fontFamily: config.string("font", default: "mono"),
+            fontSize: config.double("fontSize", default: 18),
             pageId: config.string("_pageId"),
             instanceId: config.string("_instanceId"),
             baseConfig: config
@@ -88,7 +88,7 @@ private struct StickyNoteWidgetView: View {
             textColor: NSColor(Theme.text1(ts)),
             linkColor: NSColor(primary),
             onFontSizeDelta: { delta in persistFontSize(fontSize + delta) },
-            onFontSizeReset: { persistFontSize(13) }
+            onFontSizeReset: { persistFontSize(18) }
         )
         .padding(Theme.compactPadding)
         .background(primary.opacity(tintOpacity))
@@ -121,7 +121,7 @@ private struct StickyNoteWidgetView: View {
         }
     }
 
-    /// 13 is the schema default; Cmd+0 snaps back to it.
+    /// 18 is the schema default; Cmd+0 snaps back to it.
     private func persistFontSize(_ newSize: Double) {
         guard !instanceId.isEmpty else { return }
         var config = baseConfig
@@ -372,7 +372,7 @@ private struct RichStickyTextView: NSViewRepresentable {
 /// checkboxes that toggle on click, and a strikethrough action for the
 /// Format menu.
 private final class LinkPasteTextView: NSTextView {
-    var defaultFont: NSFont = .systemFont(ofSize: 13)
+    var defaultFont: NSFont = .systemFont(ofSize: 18)
     var defaultColor: NSColor = .white
     var accentColor: NSColor = .systemYellow
     var onFontSizeDelta: ((Double) -> Void)?
@@ -397,9 +397,18 @@ private final class LinkPasteTextView: NSTextView {
         }
     }
 
+    /// Marker Felt and Noteworthy set their letters so tight on the small
+    /// panel that they blur together; a little tracking keeps them legible.
+    private var noteKern: CGFloat {
+        switch defaultFont.familyName {
+        case "Marker Felt", "Noteworthy": return defaultFont.pointSize * 0.08
+        default: return 0
+        }
+    }
+
     private var bodyAttributes: [NSAttributedString.Key: Any] {
         [.font: defaultFont, .foregroundColor: defaultColor,
-         .paragraphStyle: bodyParagraph]
+         .paragraphStyle: bodyParagraph, .kern: noteKern]
     }
 
     /// Shared rhythm for body, bullet and checkbox lines.
@@ -586,6 +595,19 @@ private final class LinkPasteTextView: NSTextView {
         }
         applyParagraphSpacing()
         renumberOrderedLists()
+        applyTracking()
+    }
+
+    /// Stamps the family's tracking over everything so loaded and pasted
+    /// text is covered, and clears it when the family doesn't need it.
+    private func applyTracking() {
+        guard let storage = textStorage, storage.length > 0 else { return }
+        let all = NSRange(location: 0, length: storage.length)
+        if noteKern > 0 {
+            storage.addAttribute(.kern, value: noteKern, range: all)
+        } else {
+            storage.removeAttribute(.kern, range: all)
+        }
     }
 
     /// Every paragraph gets its rhythm: heading-sized first characters get

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -173,8 +173,9 @@ private struct RichStickyTextView: NSViewRepresentable {
                 Self.parseLegacy(legacyMarkdown, font: baseFont, textColor: textColor)
             )
         }
+        textView.accentColor = linkColor
         textView.typingAttributes = [.font: baseFont, .foregroundColor: textColor]
-        textView.applyCheckboxCursors()
+        textView.normalizeCheckboxes()
 
         let scroll = NSScrollView()
         scroll.documentView = textView
@@ -187,6 +188,7 @@ private struct RichStickyTextView: NSViewRepresentable {
     func updateNSView(_ scroll: NSScrollView, context: Context) {
         guard let textView = scroll.documentView as? LinkPasteTextView else { return }
         textView.insertionPointColor = textColor
+        textView.accentColor = linkColor
         // Reflow the whole note when the configured font family/size changes,
         // preserving bold/italic traits and relative (heading) sizes.
         if context.coordinator.appliedFontKey != fontKey {
@@ -201,7 +203,7 @@ private struct RichStickyTextView: NSViewRepresentable {
         if Self.rtfString(textView.attributedString()) != rtfBase64,
            let restored = Self.fromRTF(rtfBase64) {
             textView.textStorage?.setAttributedString(restored)
-            textView.applyCheckboxCursors()
+            textView.normalizeCheckboxes()
         }
     }
 
@@ -271,10 +273,24 @@ private struct RichStickyTextView: NSViewRepresentable {
 
     // MARK: Storage
 
+    /// Drawn checkboxes live only in the view; storage keeps the glyph
+    /// characters, so RTF, the plain mirror and pre-attachment notes all
+    /// stay compatible.
     static func rtfString(_ attributed: NSAttributedString) -> String {
         guard attributed.length > 0 else { return "" }
-        let range = NSRange(location: 0, length: attributed.length)
-        return attributed.rtf(from: range, documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf])?
+        let mapped = NSMutableAttributedString()
+        attributed.enumerateAttributes(in: NSRange(location: 0, length: attributed.length)) { attrs, range, _ in
+            if let box = attrs[.attachment] as? CheckboxAttachment {
+                var plain = attrs
+                plain.removeValue(forKey: .attachment)
+                plain.removeValue(forKey: .cursor)
+                mapped.append(NSAttributedString(string: box.checked ? "☑" : "☐", attributes: plain))
+            } else {
+                mapped.append(attributed.attributedSubstring(from: range))
+            }
+        }
+        let range = NSRange(location: 0, length: mapped.length)
+        return mapped.rtf(from: range, documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf])?
             .base64EncodedString() ?? ""
     }
 
@@ -289,7 +305,9 @@ private struct RichStickyTextView: NSViewRepresentable {
         var out = ""
         attributed.enumerateAttributes(in: NSRange(location: 0, length: attributed.length)) { attrs, range, _ in
             let text = attributed.attributedSubstring(from: range).string
-            if let link = attrs[.link] {
+            if let box = attrs[.attachment] as? CheckboxAttachment {
+                out += box.checked ? "☑" : "☐"
+            } else if let link = attrs[.link] {
                 let url = (link as? URL)?.absoluteString ?? (link as? String ?? "")
                 out += "[\(text)](\(url))"
             } else {
@@ -325,40 +343,54 @@ private struct RichStickyTextView: NSViewRepresentable {
 private final class LinkPasteTextView: NSTextView {
     var defaultFont: NSFont = .systemFont(ofSize: 13)
     var defaultColor: NSColor = .white
+    var accentColor: NSColor = .systemYellow
+    private var isNormalizing = false
 
     private var bodyAttributes: [NSAttributedString.Key: Any] {
         [.font: defaultFont, .foregroundColor: defaultColor]
     }
 
-    /// Checkbox glyphs behave like controls, so hovering shows the hand, not
-    /// the I-beam. The .cursor attribute is hover-only and never serializes
-    /// into the RTF.
     override func didChangeText() {
         super.didChangeText()
-        applyCheckboxCursors()
+        guard !isNormalizing else { return }
+        isNormalizing = true
+        normalizeCheckboxes()
+        isNormalizing = false
     }
 
-    func applyCheckboxCursors() {
-        // Pointer cursor only. The glyph stays at body size: caret height
-        // follows line height, and line height follows the tallest glyph, so
-        // an enlarged box either grows the caret or squashes the line — both
-        // tried, both worse. This pass also repairs notes saved during the
-        // oversized-glyph experiments.
+    /// One drawn checkbox (attachment) plus its following no-break space.
+    private func checkboxMarker(checked: Bool) -> NSAttributedString {
+        let s = NSMutableAttributedString(attributedString: checkboxOnly(checked: checked))
+        s.append(NSAttributedString(string: "\u{00A0}", attributes: bodyAttributes))
+        return s
+    }
+
+    private func checkboxOnly(checked: Bool) -> NSAttributedString {
+        let attachment = CheckboxAttachment.make(
+            checked: checked, font: defaultFont,
+            stroke: defaultColor, accent: accentColor
+        )
+        let s = NSMutableAttributedString(attachment: attachment)
+        s.addAttributes(
+            [.cursor: NSCursor.pointingHand, .font: defaultFont],
+            range: NSRange(location: 0, length: s.length)
+        )
+        return s
+    }
+
+    /// Storage carries ☐/☑ characters; the view draws them. Any glyph that
+    /// appears (load, paste, legacy notes) becomes a drawn attachment.
+    func normalizeCheckboxes() {
         guard let storage = textStorage else { return }
+        var idx = storage.length - 1
         let ns = storage.string as NSString
-        var idx = 0
-        while idx < ns.length {
+        while idx >= 0 {
             let ch = ns.substring(with: NSRange(location: idx, length: 1))
             if ch == "☐" || ch == "☑" {
                 let range = NSRange(location: idx, length: 1)
-                storage.addAttributes(
-                    [.cursor: NSCursor.pointingHand, .font: defaultFont],
-                    range: range
-                )
-                storage.removeAttribute(.paragraphStyle, range: range)
-                storage.removeAttribute(.baselineOffset, range: range)
+                storage.replaceCharacters(in: range, with: checkboxOnly(checked: ch == "☑"))
             }
-            idx += 1
+            idx -= 1
         }
     }
 
@@ -420,11 +452,11 @@ private final class LinkPasteTextView: NSTextView {
         // checkbox forms chain off the bullet. Conversion waits for the
         // CLOSING bracket — converting at "[" would make "[x]" untypeable.
         case "- [ ]", "- []", "•\u{00A0}[ ]", "•\u{00A0}[]":
-            replace(prefixRange, with: NSAttributedString(string: "☐\u{00A0}", attributes: bodyAttributes))
+            replace(prefixRange, with: checkboxMarker(checked: false))
             return true
         case "- [x]", "- [X]", "•\u{00A0}[x]", "•\u{00A0}[X]",
              "•\u{00A0}[ x]", "•\u{00A0}[ X]":
-            replace(prefixRange, with: NSAttributedString(string: "☑\u{00A0}", attributes: bodyAttributes))
+            replace(prefixRange, with: checkboxMarker(checked: true))
             return true
         case "#", "##", "###":
             replace(prefixRange, with: NSAttributedString(string: ""))
@@ -475,7 +507,8 @@ private final class LinkPasteTextView: NSTextView {
         let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
         var content = ns.substring(with: lineRange)
         if content.hasSuffix("\n") { content.removeLast() }
-        let markers = ["•\u{00A0}", "☐\u{00A0}", "☑\u{00A0}", "•", "☐", "☑"]
+        let markers = ["•\u{00A0}", "☐\u{00A0}", "☑\u{00A0}", "•", "☐", "☑",
+                       "\u{FFFC}\u{00A0}", "\u{FFFC}"]
         guard markers.contains(content) else { return false }
         let deleteRange = NSRange(location: lineRange.location, length: (content as NSString).length)
         replace(deleteRange, with: NSAttributedString(string: ""))
@@ -503,17 +536,18 @@ private final class LinkPasteTextView: NSTextView {
     /// Pressing return on a bullet/checkbox line continues the list; on an
     /// empty list line it ends it (handled by the caller inserting nothing —
     /// the empty marker line stays until deleted, matching most editors).
-    private func listContinuation() -> String? {
+    private func listContinuation() -> NSAttributedString? {
         let ns = string as NSString
         let loc = selectedRange().location
         let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
         let line = ns.substring(with: lineRange)
         if line.hasPrefix("•\u{00A0}"), line.trimmingCharacters(in: .whitespacesAndNewlines) != "•" {
-            return "•\u{00A0}"
+            return NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes)
         }
-        if line.hasPrefix("☐\u{00A0}") || line.hasPrefix("☑\u{00A0}") {
+        // Drawn checkbox lines start with the attachment character.
+        if line.hasPrefix("\u{FFFC}") {
             let stripped = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if stripped != "☐" && stripped != "☑" { return "☐\u{00A0}" }
+            if stripped != "\u{FFFC}" { return checkboxMarker(checked: false) }
         }
         return nil
     }
@@ -529,14 +563,11 @@ private final class LinkPasteTextView: NSTextView {
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
         let index = characterIndexForInsertion(at: point)
-        let ns = string as NSString
-        for candidate in [index, index - 1] where candidate >= 0 && candidate < ns.length {
-            let char = ns.substring(with: NSRange(location: candidate, length: 1))
-            if char == "☐" || char == "☑" {
+        for candidate in [index, index - 1] where candidate >= 0 && candidate < (textStorage?.length ?? 0) {
+            if let box = textStorage?.attribute(.attachment, at: candidate, effectiveRange: nil) as? CheckboxAttachment {
                 let range = NSRange(location: candidate, length: 1)
-                let flipped = char == "☐" ? "☑" : "☐"
-                guard shouldChangeText(in: range, replacementString: flipped) else { break }
-                textStorage?.replaceCharacters(in: range, with: flipped)
+                guard shouldChangeText(in: range, replacementString: nil) else { break }
+                textStorage?.replaceCharacters(in: range, with: checkboxOnly(checked: !box.checked))
                 didChangeText()
                 return
             }
@@ -608,5 +639,58 @@ private final class LinkPasteTextView: NSTextView {
         guard alert.runModal() == .alertFirstButtonReturn else { return nil }
         let typed = field.stringValue.trimmingCharacters(in: .whitespaces)
         return typed.isEmpty ? defaultTitle : typed
+    }
+}
+
+// MARK: - Drawn checkbox
+
+/// Custom-drawn checkbox image the note renders in place of ☐/☑: a rounded
+/// stroke square, filled with the note's accent plus a checkmark when done.
+/// The attachment exists only in the view — serialization maps it back to
+/// the glyph characters.
+private final class CheckboxAttachment: NSTextAttachment {
+    var checked = false
+
+    static func make(checked: Bool, font: NSFont, stroke: NSColor, accent: NSColor) -> CheckboxAttachment {
+        let side = (font.pointSize * 1.2).rounded()
+        let attachment = CheckboxAttachment()
+        attachment.checked = checked
+        attachment.image = drawImage(checked: checked, side: side, stroke: stroke, accent: accent)
+        // Center against the cap height so the box reads as part of the line.
+        attachment.bounds = CGRect(
+            x: 0, y: (font.capHeight - side) / 2, width: side, height: side
+        )
+        return attachment
+    }
+
+    private static func drawImage(checked: Bool, side: CGFloat, stroke: NSColor, accent: NSColor) -> NSImage {
+        NSImage(size: NSSize(width: side, height: side), flipped: false) { rect in
+            let inset = rect.insetBy(dx: 1, dy: 1)
+            let radius = side * 0.24
+            let path = NSBezierPath(roundedRect: inset, xRadius: radius, yRadius: radius)
+            if checked {
+                accent.setFill()
+                path.fill()
+                // Checkmark in whichever of black/white reads against the accent.
+                let rgb = accent.usingColorSpace(.deviceRGB)
+                let luminance = rgb.map {
+                    0.299 * $0.redComponent + 0.587 * $0.greenComponent + 0.114 * $0.blueComponent
+                } ?? 1
+                let mark = NSBezierPath()
+                mark.move(to: NSPoint(x: side * 0.26, y: side * 0.52))
+                mark.line(to: NSPoint(x: side * 0.44, y: side * 0.32))
+                mark.line(to: NSPoint(x: side * 0.76, y: side * 0.70))
+                mark.lineWidth = max(1.5, side * 0.14)
+                mark.lineCapStyle = .round
+                mark.lineJoinStyle = .round
+                (luminance > 0.6 ? NSColor.black.withAlphaComponent(0.85) : .white).setStroke()
+                mark.stroke()
+            } else {
+                stroke.withAlphaComponent(0.75).setStroke()
+                path.lineWidth = max(1.5, side * 0.11)
+                path.stroke()
+            }
+            return true
+        }
     }
 }

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -174,6 +174,7 @@ private struct RichStickyTextView: NSViewRepresentable {
             )
         }
         textView.typingAttributes = [.font: baseFont, .foregroundColor: textColor]
+        textView.applyCheckboxCursors()
 
         let scroll = NSScrollView()
         scroll.documentView = textView
@@ -200,6 +201,7 @@ private struct RichStickyTextView: NSViewRepresentable {
         if Self.rtfString(textView.attributedString()) != rtfBase64,
            let restored = Self.fromRTF(rtfBase64) {
             textView.textStorage?.setAttributedString(restored)
+            textView.applyCheckboxCursors()
         }
     }
 
@@ -326,6 +328,28 @@ private final class LinkPasteTextView: NSTextView {
 
     private var bodyAttributes: [NSAttributedString.Key: Any] {
         [.font: defaultFont, .foregroundColor: defaultColor]
+    }
+
+    /// Checkbox glyphs behave like controls, so hovering shows the hand, not
+    /// the I-beam. The .cursor attribute is hover-only and never serializes
+    /// into the RTF.
+    override func didChangeText() {
+        super.didChangeText()
+        applyCheckboxCursors()
+    }
+
+    func applyCheckboxCursors() {
+        guard let storage = textStorage else { return }
+        let ns = storage.string as NSString
+        var idx = 0
+        while idx < ns.length {
+            let ch = ns.substring(with: NSRange(location: idx, length: 1))
+            if ch == "☐" || ch == "☑" {
+                storage.addAttribute(.cursor, value: NSCursor.pointingHand,
+                                     range: NSRange(location: idx, length: 1))
+            }
+            idx += 1
+        }
     }
 
     private func headingFont(_ level: Int) -> NSFont {

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -15,6 +15,10 @@ public final class StickyNoteWidget: DashboardWidget {
         ConfigSchemaEntry(key: "note", label: "Note", type: .text, defaultValue: .string("")),
         ConfigSchemaEntry(key: "color", label: "Color", type: .picker, defaultValue: .string("yellow"),
                           options: ["yellow", "orange", "pink", "red", "green", "mint", "blue", "purple", "gray"]),
+        ConfigSchemaEntry(key: "textColor", label: "Text Color", type: .picker,
+                          defaultValue: .string("soft white"),
+                          options: ["soft white", "white", "gray", "black", "yellow", "orange",
+                                    "pink", "red", "green", "mint", "blue", "purple"]),
         ConfigSchemaEntry(key: "opacity", label: "Opacity", type: .slider, defaultValue: .double(0.5),
                           minValue: 0.0, maxValue: 1.0, step: 0.05),
         ConfigSchemaEntry(key: "font", label: "Font", type: .picker, defaultValue: .string("mono"),
@@ -32,6 +36,7 @@ public final class StickyNoteWidget: DashboardWidget {
             note: config.string("note"),
             rtf: config.string("rtf"),
             colorName: config.string("color", default: "yellow"),
+            textColorName: config.string("textColor", default: "soft white"),
             tintOpacity: config.double("opacity", default: 0.5),
             fontFamily: config.string("font", default: "mono"),
             fontSize: config.double("fontSize", default: 18),
@@ -51,6 +56,7 @@ private struct StickyNoteWidgetView: View {
     let note: String
     let rtf: String
     let colorName: String
+    let textColorName: String
     let tintOpacity: Double
     let fontFamily: String
     let fontSize: Double
@@ -79,13 +85,32 @@ private struct StickyNoteWidgetView: View {
         }
     }
 
+    /// "soft white" is a touch darker than pure white — easier on the eyes
+    /// against the tinted card.
+    private var textNSColor: NSColor {
+        switch textColorName {
+        case "white": .white
+        case "gray": .systemGray
+        case "black": .black
+        case "yellow": .systemYellow
+        case "orange": .systemOrange
+        case "pink": .systemPink
+        case "red": .systemRed
+        case "green": .systemGreen
+        case "mint": .systemMint
+        case "blue": .systemBlue
+        case "purple": .systemPurple
+        default: NSColor(white: 0.85, alpha: 1)
+        }
+    }
+
     var body: some View {
         RichStickyTextView(
             rtfBase64: $rtfDraft,
             plainText: $plainDraft,
             legacyMarkdown: note,
             baseFont: RichStickyTextView.makeFont(family: fontFamily, size: fontSize * ts.fontScale),
-            textColor: NSColor(Theme.text1(ts)),
+            textColor: textNSColor,
             linkColor: NSColor(primary),
             onFontSizeDelta: { delta in persistFontSize(fontSize + delta) },
             onFontSizeReset: { persistFontSize(18) }
@@ -183,6 +208,7 @@ private struct RichStickyTextView: NSViewRepresentable {
         textView.defaultColor = textColor
         textView.insertionPointColor = textColor
         context.coordinator.appliedFontKey = fontKey
+        context.coordinator.appliedColorKey = colorKey
 
         if let restored = Self.fromRTF(rtfBase64) {
             textView.textStorage?.setAttributedString(restored)
@@ -212,11 +238,12 @@ private struct RichStickyTextView: NSViewRepresentable {
         textView.onFontSizeDelta = onFontSizeDelta
         textView.onFontSizeReset = onFontSizeReset
         let fontChanged = context.coordinator.appliedFontKey != fontKey
+        let colorChanged = context.coordinator.appliedColorKey != colorKey
         // Reload only on a genuine external change — and never on the pass
-        // that changes the font: the binding still holds pre-reflow RTF then,
-        // and reloading from it would undo the text scaling while the
-        // checkbox images resized (the bug that shipped first).
-        if !fontChanged,
+        // that changes the font or color: the binding still holds the
+        // pre-restyle RTF then, and reloading from it would undo the reflow
+        // or recolor (the bug that shipped first).
+        if !fontChanged, !colorChanged,
            Self.rtfString(textView.attributedString()) != rtfBase64,
            let restored = Self.fromRTF(rtfBase64) {
             textView.textStorage?.setAttributedString(restored)
@@ -236,9 +263,35 @@ private struct RichStickyTextView: NSViewRepresentable {
             let coordinator = context.coordinator
             DispatchQueue.main.async { coordinator.pushChanges(from: textView) }
         }
+        // Recolor when the configured text color changes: every non-link
+        // run takes the new color (dimmed runs like rules keep their alpha),
+        // and the checkboxes redraw their strokes to match.
+        if colorChanged {
+            textView.defaultColor = textColor
+            recolorText(in: textView)
+            context.coordinator.appliedColorKey = colorKey
+            textView.refreshCheckboxImages()
+            textView.normalizeCheckboxes()
+            let coordinator = context.coordinator
+            DispatchQueue.main.async { coordinator.pushChanges(from: textView) }
+        }
     }
 
     private var fontKey: String { "\(baseFont.fontName)-\(baseFont.pointSize)" }
+    private var colorKey: String { textColor.description }
+
+    private func recolorText(in textView: LinkPasteTextView) {
+        guard let storage = textView.textStorage, storage.length > 0 else { return }
+        storage.beginEditing()
+        storage.enumerateAttribute(.foregroundColor, in: NSRange(location: 0, length: storage.length)) { value, range, _ in
+            if storage.attribute(.link, at: range.location, effectiveRange: nil) != nil { return }
+            let alpha = (value as? NSColor)?.alphaComponent ?? 1
+            let color = alpha < 1 ? textColor.withAlphaComponent(alpha) : textColor
+            storage.addAttribute(.foregroundColor, value: color, range: range)
+        }
+        storage.endEditing()
+        textView.typingAttributes[.foregroundColor] = textColor
+    }
 
     private func reapplyBaseFont(in textView: LinkPasteTextView, ratio: CGFloat) {
         guard let storage = textView.textStorage else { return }
@@ -282,6 +335,7 @@ private struct RichStickyTextView: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: RichStickyTextView
         var appliedFontKey = ""
+        var appliedColorKey = ""
         init(_ parent: RichStickyTextView) { self.parent = parent }
 
         func textDidChange(_ notification: Notification) {

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -399,12 +399,13 @@ private final class LinkPasteTextView: NSTextView {
             replace(prefixRange, with: NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes))
             return true
         // "- " already became a bullet by the time "[ ]" is typed, so the
-        // checkbox forms chain off the bullet: "• [" + space completes it.
-        case "- [", "- [ ]", "- []",
-             "•\u{00A0}[", "•\u{00A0}[ ]", "•\u{00A0}[]":
+        // checkbox forms chain off the bullet. Conversion waits for the
+        // CLOSING bracket — converting at "[" would make "[x]" untypeable.
+        case "- [ ]", "- []", "•\u{00A0}[ ]", "•\u{00A0}[]":
             replace(prefixRange, with: NSAttributedString(string: "☐\u{00A0}", attributes: bodyAttributes))
             return true
-        case "- [x]", "- [X]", "•\u{00A0}[x]", "•\u{00A0}[X]":
+        case "- [x]", "- [X]", "•\u{00A0}[x]", "•\u{00A0}[X]",
+             "•\u{00A0}[ x]", "•\u{00A0}[ X]":
             replace(prefixRange, with: NSAttributedString(string: "☑\u{00A0}", attributes: bodyAttributes))
             return true
         case "#", "##", "###":

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -17,6 +17,10 @@ public final class StickyNoteWidget: DashboardWidget {
                           options: ["yellow", "orange", "pink", "red", "green", "mint", "blue", "purple", "gray"]),
         ConfigSchemaEntry(key: "opacity", label: "Opacity", type: .slider, defaultValue: .double(0.12),
                           minValue: 0.0, maxValue: 1.0, step: 0.05),
+        ConfigSchemaEntry(key: "font", label: "Font", type: .picker, defaultValue: .string("system"),
+                          options: ["system", "rounded", "serif", "mono", "marker", "noteworthy"]),
+        ConfigSchemaEntry(key: "fontSize", label: "Font Size", type: .slider, defaultValue: .double(13),
+                          minValue: 10, maxValue: 24, step: 1),
     ]
     public let defaultColors = WidgetColors(primary: .yellow)
 
@@ -26,8 +30,11 @@ public final class StickyNoteWidget: DashboardWidget {
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
         StickyNoteWidgetView(
             note: config.string("note"),
+            rtf: config.string("rtf"),
             colorName: config.string("color", default: "yellow"),
             tintOpacity: config.double("opacity", default: 0.12),
+            fontFamily: config.string("font", default: "system"),
+            fontSize: config.double("fontSize", default: 13),
             pageId: config.string("_pageId"),
             instanceId: config.string("_instanceId"),
             baseConfig: config
@@ -35,20 +42,26 @@ public final class StickyNoteWidget: DashboardWidget {
     }
 }
 
-/// Always-editable rich text: links live inline as styled, clickable titles.
-/// Storage stays plain — links serialize to `[title](url)` in the config, so
-/// notes round-trip through export/import and the settings field.
+/// A markdown-lite rich note: type "- ", "- [ ] ", "# " or "---" and they
+/// convert to bullets, checkboxes, headings and rules on the spot — the note
+/// is rich text from then on, never markdown. Links paste as titled links.
+/// Storage is RTF (with a plain-text mirror in "note" for the settings field
+/// and for pre-RTF notes).
 private struct StickyNoteWidgetView: View {
     let note: String
+    let rtf: String
     let colorName: String
     let tintOpacity: Double
+    let fontFamily: String
+    let fontSize: Double
     let pageId: String
     let instanceId: String
     let baseConfig: WidgetConfig
 
     @EnvironmentObject private var layoutEngine: LayoutEngine
     @Environment(\.themeSettings) private var ts
-    @State private var draft = ""
+    @State private var rtfDraft = ""
+    @State private var plainDraft = ""
     @State private var seeded = false
     @State private var saveTask: Task<Void, Never>?
 
@@ -68,8 +81,10 @@ private struct StickyNoteWidgetView: View {
 
     var body: some View {
         RichStickyTextView(
-            markdown: $draft,
-            font: NSFont.systemFont(ofSize: 13 * ts.fontScale),
+            rtfBase64: $rtfDraft,
+            plainText: $plainDraft,
+            legacyMarkdown: note,
+            baseFont: RichStickyTextView.makeFont(family: fontFamily, size: fontSize * ts.fontScale),
             textColor: NSColor(Theme.text1(ts)),
             linkColor: NSColor(primary)
         )
@@ -78,37 +93,39 @@ private struct StickyNoteWidgetView: View {
         .widgetCard()
         .onAppear {
             if !seeded {
-                draft = note
+                rtfDraft = rtf
+                plainDraft = note
                 seeded = true
             }
         }
         // External edits (settings field, layout import) win over a stale
         // on-screen draft only when they actually differ.
-        .onChange(of: note) { _, newValue in
-            if newValue != draft { draft = newValue }
+        .onChange(of: rtf) { _, newValue in
+            if newValue != rtfDraft { rtfDraft = newValue }
         }
         // Debounced: saving mutates the layout document, and doing that per
         // keystroke re-rendered every widget on the dashboard per character.
-        .onChange(of: draft) { _, newValue in
+        .onChange(of: rtfDraft) { _, _ in
             saveTask?.cancel()
             saveTask = Task { @MainActor in
                 try? await Task.sleep(for: .milliseconds(800))
                 guard !Task.isCancelled else { return }
-                save(newValue)
+                save()
             }
         }
         .onDisappear {
             saveTask?.cancel()
-            save(draft)
+            save()
         }
     }
 
-    private func save(_ text: String) {
-        guard !instanceId.isEmpty, text != note else { return }
+    private func save() {
+        guard !instanceId.isEmpty, rtfDraft != rtf else { return }
         // Strip the injected identity keys: they describe the render pass,
         // not the widget's persistent state.
         var config = baseConfig
-        config["note"] = .string(text)
+        config["rtf"] = .string(rtfDraft)
+        config["note"] = .string(plainDraft)
         config["_pageId"] = nil
         config["_instanceId"] = nil
         layoutEngine.updateWidgetConfig(pageId: pageId, instanceId: instanceId, config: config)
@@ -117,12 +134,11 @@ private struct StickyNoteWidgetView: View {
 
 // MARK: - Rich text view
 
-/// NSTextView wrapper: rich in the view, `[title](url)` in storage. Pasting
-/// a URL over selected text linkifies the selection; pasting a bare URL asks
-/// for a title. Clicking a link opens it, even while editable.
 private struct RichStickyTextView: NSViewRepresentable {
-    @Binding var markdown: String
-    let font: NSFont
+    @Binding var rtfBase64: String
+    @Binding var plainText: String
+    let legacyMarkdown: String
+    let baseFont: NSFont
     let textColor: NSColor
     let linkColor: NSColor
 
@@ -131,6 +147,7 @@ private struct RichStickyTextView: NSViewRepresentable {
         textView.delegate = context.coordinator
         textView.isRichText = true
         textView.allowsUndo = true
+        textView.usesFontPanel = true
         textView.drawsBackground = false
         textView.focusRingType = .none
         textView.isAutomaticQuoteSubstitutionEnabled = false
@@ -144,10 +161,19 @@ private struct RichStickyTextView: NSViewRepresentable {
             .underlineStyle: NSUnderlineStyle.single.rawValue,
             .cursor: NSCursor.pointingHand,
         ]
-        applyStyle(to: textView)
-        textView.textStorage?.setAttributedString(
-            Self.parse(markdown, font: font, textColor: textColor)
-        )
+        textView.defaultFont = baseFont
+        textView.defaultColor = textColor
+        textView.insertionPointColor = textColor
+        context.coordinator.appliedFontKey = fontKey
+
+        if let restored = Self.fromRTF(rtfBase64) {
+            textView.textStorage?.setAttributedString(restored)
+        } else {
+            textView.textStorage?.setAttributedString(
+                Self.parseLegacy(legacyMarkdown, font: baseFont, textColor: textColor)
+            )
+        }
+        textView.typingAttributes = [.font: baseFont, .foregroundColor: textColor]
 
         let scroll = NSScrollView()
         scroll.documentView = textView
@@ -159,33 +185,79 @@ private struct RichStickyTextView: NSViewRepresentable {
 
     func updateNSView(_ scroll: NSScrollView, context: Context) {
         guard let textView = scroll.documentView as? LinkPasteTextView else { return }
-        applyStyle(to: textView)
-        // Only reload content on a genuine external change; echoing our own
+        textView.insertionPointColor = textColor
+        // Reflow the whole note when the configured font family/size changes,
+        // preserving bold/italic traits and relative (heading) sizes.
+        if context.coordinator.appliedFontKey != fontKey {
+            let ratio = baseFont.pointSize / textView.defaultFont.pointSize
+            reapplyBaseFont(in: textView, ratio: ratio)
+            textView.defaultFont = baseFont
+            context.coordinator.appliedFontKey = fontKey
+            context.coordinator.pushChanges(from: textView)
+        }
+        // Reload only on a genuine external change; echoing our own
         // keystrokes back through setAttributedString would fight the cursor.
-        if Self.serialize(textView.attributedString()) != markdown {
-            textView.textStorage?.setAttributedString(
-                Self.parse(markdown, font: font, textColor: textColor)
-            )
+        if Self.rtfString(textView.attributedString()) != rtfBase64,
+           let restored = Self.fromRTF(rtfBase64) {
+            textView.textStorage?.setAttributedString(restored)
         }
     }
 
-    private func applyStyle(to textView: LinkPasteTextView) {
-        textView.font = font
-        textView.textColor = textColor
-        textView.insertionPointColor = textColor
-        textView.defaultFont = font
-        textView.defaultColor = textColor
+    private var fontKey: String { "\(baseFont.fontName)-\(baseFont.pointSize)" }
+
+    private func reapplyBaseFont(in textView: LinkPasteTextView, ratio: CGFloat) {
+        guard let storage = textView.textStorage else { return }
+        storage.beginEditing()
+        storage.enumerateAttribute(.font, in: NSRange(location: 0, length: storage.length)) { value, range, _ in
+            guard let old = value as? NSFont else { return }
+            let traits = old.fontDescriptor.symbolicTraits
+            var descriptor = baseFont.fontDescriptor.withSymbolicTraits(traits)
+            if NSFont(descriptor: descriptor, size: 0) == nil { descriptor = baseFont.fontDescriptor }
+            let newFont = NSFont(descriptor: descriptor, size: old.pointSize * ratio)
+                ?? baseFont
+            storage.addAttribute(.font, value: newFont, range: range)
+        }
+        storage.endEditing()
+        textView.typingAttributes[.font] = baseFont
+    }
+
+    static func makeFont(family: String, size: Double) -> NSFont {
+        let s = CGFloat(size)
+        switch family {
+        case "mono":
+            return .monospacedSystemFont(ofSize: s, weight: .regular)
+        case "rounded":
+            let d = NSFont.systemFont(ofSize: s).fontDescriptor.withDesign(.rounded)
+            return d.flatMap { NSFont(descriptor: $0, size: s) } ?? .systemFont(ofSize: s)
+        case "serif":
+            let d = NSFont.systemFont(ofSize: s).fontDescriptor.withDesign(.serif)
+            return d.flatMap { NSFont(descriptor: $0, size: s) } ?? .systemFont(ofSize: s)
+        case "marker":
+            return NSFont(name: "Marker Felt", size: s) ?? .systemFont(ofSize: s)
+        case "noteworthy":
+            return NSFont(name: "Noteworthy", size: s) ?? .systemFont(ofSize: s)
+        default:
+            return .systemFont(ofSize: s)
+        }
     }
 
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
+    @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: RichStickyTextView
+        var appliedFontKey = ""
         init(_ parent: RichStickyTextView) { self.parent = parent }
 
         func textDidChange(_ notification: Notification) {
             guard let textView = notification.object as? NSTextView else { return }
-            parent.markdown = RichStickyTextView.serialize(textView.attributedString())
+            pushChanges(from: textView)
+        }
+
+        func pushChanges(from textView: NSTextView) {
+            let attributed = textView.attributedString()
+            parent.rtfBase64 = RichStickyTextView.rtfString(attributed)
+            parent.plainText = RichStickyTextView.plainMirror(attributed)
         }
 
         func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
@@ -195,9 +267,23 @@ private struct RichStickyTextView: NSViewRepresentable {
         }
     }
 
-    // MARK: Markdown round-trip (links only, nothing else interpreted)
+    // MARK: Storage
 
-    static func serialize(_ attributed: NSAttributedString) -> String {
+    static func rtfString(_ attributed: NSAttributedString) -> String {
+        guard attributed.length > 0 else { return "" }
+        let range = NSRange(location: 0, length: attributed.length)
+        return attributed.rtf(from: range, documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf])?
+            .base64EncodedString() ?? ""
+    }
+
+    static func fromRTF(_ base64: String) -> NSAttributedString? {
+        guard !base64.isEmpty, let data = Data(base64Encoded: base64) else { return nil }
+        return NSAttributedString(rtf: data, documentAttributes: nil)
+    }
+
+    /// Plain mirror for the settings field / export readability: links keep
+    /// their [title](url) form, formatting is dropped.
+    static func plainMirror(_ attributed: NSAttributedString) -> String {
         var out = ""
         attributed.enumerateAttributes(in: NSRange(location: 0, length: attributed.length)) { attrs, range, _ in
             let text = attributed.attributedSubstring(from: range).string
@@ -211,7 +297,8 @@ private struct RichStickyTextView: NSViewRepresentable {
         return out
     }
 
-    static func parse(_ markdown: String, font: NSFont, textColor: NSColor) -> NSAttributedString {
+    /// Pre-RTF notes stored `[title](url)` markdown; parse once on load.
+    static func parseLegacy(_ markdown: String, font: NSFont, textColor: NSColor) -> NSAttributedString {
         let plain: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: textColor]
         let result = NSMutableAttributedString()
         var rest = Substring(markdown)
@@ -228,10 +315,163 @@ private struct RichStickyTextView: NSViewRepresentable {
     }
 }
 
-/// The paste override that makes URLs become links instead of sprawling text.
+// MARK: - The editor
+
+/// Markdown-lite conversions at the keystroke, links on paste, glyph
+/// checkboxes that toggle on click, and a strikethrough action for the
+/// Format menu.
 private final class LinkPasteTextView: NSTextView {
     var defaultFont: NSFont = .systemFont(ofSize: 13)
     var defaultColor: NSColor = .white
+
+    private var bodyAttributes: [NSAttributedString.Key: Any] {
+        [.font: defaultFont, .foregroundColor: defaultColor]
+    }
+
+    private func headingFont(_ level: Int) -> NSFont {
+        let scale: CGFloat = level == 1 ? 1.6 : level == 2 ? 1.35 : 1.15
+        let descriptor = defaultFont.fontDescriptor.withSymbolicTraits(
+            defaultFont.fontDescriptor.symbolicTraits.union(.bold)
+        )
+        return NSFont(descriptor: descriptor, size: defaultFont.pointSize * scale)
+            ?? .boldSystemFont(ofSize: defaultFont.pointSize * scale)
+    }
+
+    // MARK: Typing conversions
+
+    override func insertText(_ insertString: Any, replacementRange: NSRange) {
+        let str = (insertString as? String)
+            ?? (insertString as? NSAttributedString)?.string ?? ""
+
+        if str == " ", convertLinePrefix() { return }
+
+        if str == "\n" {
+            if convertHorizontalRule() { return }
+            let continuation = listContinuation()
+            super.insertText(insertString, replacementRange: replacementRange)
+            // A heading ends at the line break; typing resumes as body text.
+            typingAttributes = bodyAttributes
+            if let continuation {
+                super.insertText(continuation, replacementRange: selectedRange())
+            }
+            return
+        }
+
+        super.insertText(insertString, replacementRange: replacementRange)
+    }
+
+    /// "- " → bullet, "- [ ] " → checkbox, "# "/"## "/"### " → heading.
+    /// Called when a space is typed; returns true when the space is consumed.
+    private func convertLinePrefix() -> Bool {
+        let ns = string as NSString
+        let loc = selectedRange().location
+        let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
+        guard loc >= lineRange.location else { return false }
+        let prefixRange = NSRange(location: lineRange.location, length: loc - lineRange.location)
+        let prefix = ns.substring(with: prefixRange)
+
+        switch prefix {
+        case "-":
+            replace(prefixRange, with: NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes))
+            return true
+        case "- [", "- [ ]", "- []":
+            replace(prefixRange, with: NSAttributedString(string: "☐\u{00A0}", attributes: bodyAttributes))
+            return true
+        case "- [x]", "- [X]":
+            replace(prefixRange, with: NSAttributedString(string: "☑\u{00A0}", attributes: bodyAttributes))
+            return true
+        case "#", "##", "###":
+            replace(prefixRange, with: NSAttributedString(string: ""))
+            var attrs = bodyAttributes
+            attrs[.font] = headingFont(prefix.count)
+            typingAttributes = attrs
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// A line reading exactly "---" becomes a dim horizontal rule on return.
+    private func convertHorizontalRule() -> Bool {
+        let ns = string as NSString
+        let loc = selectedRange().location
+        let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
+        let line = ns.substring(with: lineRange).trimmingCharacters(in: .newlines)
+        guard line == "---" else { return false }
+        var attrs = bodyAttributes
+        attrs[.foregroundColor] = defaultColor.withAlphaComponent(0.35)
+        let rule = NSMutableAttributedString(
+            string: String(repeating: "─", count: 24) + "\n", attributes: attrs
+        )
+        replace(lineRange, with: rule)
+        typingAttributes = bodyAttributes
+        return true
+    }
+
+    /// Pressing return on a bullet/checkbox line continues the list; on an
+    /// empty list line it ends it (handled by the caller inserting nothing —
+    /// the empty marker line stays until deleted, matching most editors).
+    private func listContinuation() -> String? {
+        let ns = string as NSString
+        let loc = selectedRange().location
+        let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
+        let line = ns.substring(with: lineRange)
+        if line.hasPrefix("•\u{00A0}"), line.trimmingCharacters(in: .whitespacesAndNewlines) != "•" {
+            return "•\u{00A0}"
+        }
+        if line.hasPrefix("☐\u{00A0}") || line.hasPrefix("☑\u{00A0}") {
+            let stripped = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            if stripped != "☐" && stripped != "☑" { return "☐\u{00A0}" }
+        }
+        return nil
+    }
+
+    private func replace(_ range: NSRange, with attributed: NSAttributedString) {
+        guard shouldChangeText(in: range, replacementString: attributed.string) else { return }
+        textStorage?.replaceCharacters(in: range, with: attributed)
+        didChangeText()
+    }
+
+    // MARK: Checkbox toggling
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        let index = characterIndexForInsertion(at: point)
+        let ns = string as NSString
+        for candidate in [index, index - 1] where candidate >= 0 && candidate < ns.length {
+            let char = ns.substring(with: NSRange(location: candidate, length: 1))
+            if char == "☐" || char == "☑" {
+                let range = NSRange(location: candidate, length: 1)
+                let flipped = char == "☐" ? "☑" : "☐"
+                guard shouldChangeText(in: range, replacementString: flipped) else { break }
+                textStorage?.replaceCharacters(in: range, with: flipped)
+                didChangeText()
+                return
+            }
+        }
+        super.mouseDown(with: event)
+    }
+
+    // MARK: Strikethrough (Format menu)
+
+    @objc func toggleStrikethrough(_ sender: Any?) {
+        let range = selectedRange()
+        guard range.length > 0, let storage = textStorage else {
+            let current = typingAttributes[.strikethroughStyle] as? Int ?? 0
+            typingAttributes[.strikethroughStyle] = current == 0 ? NSUnderlineStyle.single.rawValue : 0
+            return
+        }
+        guard shouldChangeText(in: range, replacementString: nil) else { return }
+        let current = storage.attribute(.strikethroughStyle, at: range.location, effectiveRange: nil) as? Int ?? 0
+        if current == 0 {
+            storage.addAttribute(.strikethroughStyle, value: NSUnderlineStyle.single.rawValue, range: range)
+        } else {
+            storage.removeAttribute(.strikethroughStyle, range: range)
+        }
+        didChangeText()
+    }
+
+    // MARK: Link paste
 
     override func paste(_ sender: Any?) {
         guard let pasted = NSPasteboard.general.string(forType: .string)?
@@ -249,9 +489,8 @@ private final class LinkPasteTextView: NSTextView {
             textStorage?.addAttribute(.link, value: pasted, range: range)
             didChangeText()
         } else if let title = Self.promptForTitle(defaultTitle: URL(string: pasted)?.host ?? "link") {
-            let attrs: [NSAttributedString.Key: Any] = [
-                .font: defaultFont, .foregroundColor: defaultColor, .link: pasted,
-            ]
+            var attrs = bodyAttributes
+            attrs[.link] = pasted
             insertText(NSAttributedString(string: title, attributes: attrs), replacementRange: range)
             // Continued typing must not extend the link.
             typingAttributes[.link] = nil

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -12,6 +12,10 @@ public final class StickyNoteWidget: DashboardWidget {
 
     public let configSchema: [ConfigSchemaEntry] = [
         ConfigSchemaEntry(key: "note", label: "Note", type: .text, defaultValue: .string("")),
+        ConfigSchemaEntry(key: "color", label: "Color", type: .picker, defaultValue: .string("yellow"),
+                          options: ["yellow", "orange", "pink", "red", "green", "mint", "blue", "purple", "gray"]),
+        ConfigSchemaEntry(key: "opacity", label: "Opacity", type: .slider, defaultValue: .double(0.12),
+                          minValue: 0.0, maxValue: 1.0, step: 0.05),
     ]
     public let defaultColors = WidgetColors(primary: .yellow)
 
@@ -21,6 +25,8 @@ public final class StickyNoteWidget: DashboardWidget {
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
         StickyNoteWidgetView(
             note: config.string("note"),
+            colorName: config.string("color", default: "yellow"),
+            tintOpacity: config.double("opacity", default: 0.12),
             pageId: config.string("_pageId"),
             instanceId: config.string("_instanceId"),
             baseConfig: config
@@ -30,6 +36,8 @@ public final class StickyNoteWidget: DashboardWidget {
 
 private struct StickyNoteWidgetView: View {
     let note: String
+    let colorName: String
+    let tintOpacity: Double
     let pageId: String
     let instanceId: String
     let baseConfig: WidgetConfig
@@ -39,7 +47,19 @@ private struct StickyNoteWidgetView: View {
     @State private var draft = ""
     @State private var seeded = false
 
-    private var primary: Color { Theme.widgetPrimary("sticky-note", ts: ts, default: .yellow) }
+    private var primary: Color {
+        switch colorName {
+        case "orange": .orange
+        case "pink": .pink
+        case "red": .red
+        case "green": .green
+        case "mint": .mint
+        case "blue": .blue
+        case "purple": .purple
+        case "gray": .gray
+        default: Theme.widgetPrimary("sticky-note", ts: ts, default: .yellow)
+        }
+    }
 
     var body: some View {
         TextEditor(text: $draft)
@@ -48,7 +68,7 @@ private struct StickyNoteWidgetView: View {
             .scrollContentBackground(.hidden)
             .scrollIndicators(.never)
             .padding(Theme.compactPadding)
-            .background(primary.opacity(0.10))
+            .background(primary.opacity(tintOpacity))
             .widgetCard()
             .onAppear {
                 if !seeded {

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -409,6 +409,26 @@ private final class LinkPasteTextView: NSTextView {
         return p
     }
 
+    /// Column where list text begins; markers sit flush left before a tab.
+    private var listTextIndent: CGFloat { (defaultFont.pointSize * 2.1).rounded() }
+
+    /// List lines: marker, tab, text — one shared text column for bullets,
+    /// checkboxes and numerals, with wrapped lines hanging under the text.
+    private var listParagraph: NSParagraphStyle {
+        let p = NSMutableParagraphStyle()
+        p.paragraphSpacing = defaultFont.pointSize * 0.22
+        p.tabStops = [NSTextTab(textAlignment: .left, location: listTextIndent)]
+        p.defaultTabInterval = listTextIndent
+        p.headIndent = listTextIndent
+        return p
+    }
+
+    private var listAttributes: [NSAttributedString.Key: Any] {
+        var a = bodyAttributes
+        a[.paragraphStyle] = listParagraph
+        return a
+    }
+
     /// Headings breathe a little more, especially above.
     private var headingParagraph: NSParagraphStyle {
         let p = NSMutableParagraphStyle()
@@ -456,7 +476,7 @@ private final class LinkPasteTextView: NSTextView {
     /// One drawn checkbox (attachment) plus its following no-break space.
     private func checkboxMarker(checked: Bool) -> NSAttributedString {
         let s = NSMutableAttributedString(attributedString: checkboxOnly(checked: checked))
-        s.append(NSAttributedString(string: "\u{00A0}", attributes: bodyAttributes))
+        s.append(NSAttributedString(string: "\t", attributes: listAttributes))
         return s
     }
 
@@ -495,13 +515,31 @@ private final class LinkPasteTextView: NSTextView {
     /// of normalization so loaded and pasted content is covered too.
     private func applyParagraphSpacing() {
         guard let storage = textStorage, storage.length > 0 else { return }
-        let ns = storage.string as NSString
         let headingThreshold = defaultFont.pointSize * 1.1
         var location = 0
-        while location < ns.length {
+        while location < (storage.string as NSString).length {
+            let ns = storage.string as NSString
             let paragraph = ns.lineRange(for: NSRange(location: location, length: 0))
+            var line = ns.substring(with: paragraph)
+            if line.hasSuffix("\n") { line.removeLast() }
+
+            // Migrate legacy no-break-space separators to tabs so old notes
+            // pick up the aligned list column; re-run the same paragraph.
+            if line.count >= 2, line.hasPrefix("•\u{00A0}") || line.hasPrefix("\u{FFFC}\u{00A0}") {
+                storage.replaceCharacters(
+                    in: NSRange(location: paragraph.location + 1, length: 1), with: "\t"
+                )
+                continue
+            }
+
+            let isList = line.hasPrefix("•\t") || line.hasPrefix("\u{FFFC}\t") || {
+                guard let tab = line.firstIndex(of: "\t") else { return false }
+                let head = line[..<tab]
+                return head.hasSuffix(".") && Int(head.dropLast()) != nil && !head.dropLast().isEmpty
+            }()
             let firstFont = storage.attribute(.font, at: paragraph.location, effectiveRange: nil) as? NSFont
-            let style = (firstFont?.pointSize ?? 0) > headingThreshold ? headingParagraph : bodyParagraph
+            let isHeading = (firstFont?.pointSize ?? 0) > headingThreshold
+            let style = isHeading ? headingParagraph : (isList ? listParagraph : bodyParagraph)
             storage.addAttribute(.paragraphStyle, value: style, range: paragraph)
             location = paragraph.location + paragraph.length
         }
@@ -567,11 +605,11 @@ private final class LinkPasteTextView: NSTextView {
         // "- " already became a bullet by the time "[ ]" is typed, so the
         // checkbox forms chain off the bullet. Conversion waits for the
         // CLOSING bracket — converting at "[" would make "[x]" untypeable.
-        case "- [ ]", "- []", "•\u{00A0}[ ]", "•\u{00A0}[]":
+        case "- [ ]", "- []", "•\u{00A0}[ ]", "•\u{00A0}[]", "•\t[ ]", "•\t[]":
             replace(prefixRange, with: checkboxMarker(checked: false))
             return true
         case "- [x]", "- [X]", "•\u{00A0}[x]", "•\u{00A0}[X]",
-             "•\u{00A0}[ x]", "•\u{00A0}[ X]":
+             "•\u{00A0}[ x]", "•\u{00A0}[ X]", "•\t[x]", "•\t[X]", "•\t[ x]", "•\t[ X]":
             replace(prefixRange, with: checkboxMarker(checked: true))
             return true
         case "#", "##", "###":
@@ -582,6 +620,11 @@ private final class LinkPasteTextView: NSTextView {
             typingAttributes = attrs
             return true
         default:
+            // Ordered list: any number followed by "." and a space.
+            if prefix.hasSuffix("."), prefix.count <= 5, Int(prefix.dropLast()) != nil {
+                replace(prefixRange, with: NSAttributedString(string: prefix + "\t", attributes: listAttributes))
+                return true
+            }
             return false
         }
     }
@@ -614,7 +657,7 @@ private final class LinkPasteTextView: NSTextView {
         let prefixRange = NSRange(location: lineRange.location, length: 2)
         let prefix = ns.substring(with: prefixRange)
         guard prefix == "- " || prefix == "* " else { return }
-        replace(prefixRange, with: NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes))
+        replace(prefixRange, with: NSAttributedString(string: "•\t", attributes: listAttributes))
     }
 
     /// Typing "-" or "*" right after a fresh checkbox marker switches the
@@ -624,12 +667,13 @@ private final class LinkPasteTextView: NSTextView {
         let ns = string as NSString
         let loc = selectedRange().location
         let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
+        let marker = ns.substring(with: NSRange(location: lineRange.location, length: min(2, ns.length - lineRange.location)))
         guard loc - lineRange.location == 2,
-              ns.substring(with: NSRange(location: lineRange.location, length: 2)) == "\u{FFFC}\u{00A0}",
+              marker == "\u{FFFC}\t" || marker == "\u{FFFC}\u{00A0}",
               storage.attribute(.attachment, at: lineRange.location, effectiveRange: nil) is CheckboxAttachment
         else { return false }
         let markerRange = NSRange(location: lineRange.location, length: 2)
-        replace(markerRange, with: NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes))
+        replace(markerRange, with: NSAttributedString(string: "•\t", attributes: listAttributes))
         return true
     }
 
@@ -642,8 +686,12 @@ private final class LinkPasteTextView: NSTextView {
         var content = ns.substring(with: lineRange)
         if content.hasSuffix("\n") { content.removeLast() }
         let markers = ["•\u{00A0}", "☐\u{00A0}", "☑\u{00A0}", "•", "☐", "☑",
-                       "\u{FFFC}\u{00A0}", "\u{FFFC}"]
-        guard markers.contains(content) else { return false }
+                       "\u{FFFC}\u{00A0}", "\u{FFFC}", "•\t", "\u{FFFC}\t"]
+        let bareNumber: Bool = {
+            let head = content.hasSuffix("\t") ? String(content.dropLast()) : content
+            return head.hasSuffix(".") && Int(head.dropLast()) != nil && !head.dropLast().isEmpty
+        }()
+        guard markers.contains(content) || bareNumber else { return false }
         let deleteRange = NSRange(location: lineRange.location, length: (content as NSString).length)
         replace(deleteRange, with: NSAttributedString(string: ""))
         typingAttributes = bodyAttributes
@@ -674,14 +722,25 @@ private final class LinkPasteTextView: NSTextView {
         let ns = string as NSString
         let loc = selectedRange().location
         let lineRange = ns.lineRange(for: NSRange(location: loc, length: 0))
-        let line = ns.substring(with: lineRange)
-        if line.hasPrefix("•\u{00A0}"), line.trimmingCharacters(in: .whitespacesAndNewlines) != "•" {
-            return NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes)
+        var line = ns.substring(with: lineRange)
+        if line.hasSuffix("\n") { line.removeLast() }
+        func hasContent(after marker: String) -> Bool {
+            !line.dropFirst(marker.count).trimmingCharacters(in: .whitespaces).isEmpty
         }
-        // Drawn checkbox lines start with the attachment character.
-        if line.hasPrefix("\u{FFFC}") {
-            let stripped = line.trimmingCharacters(in: .whitespacesAndNewlines)
-            if stripped != "\u{FFFC}" { return checkboxMarker(checked: false) }
+        for sep in ["\t", "\u{00A0}"] {
+            if line.hasPrefix("•" + sep) {
+                return hasContent(after: "•" + sep)
+                    ? NSAttributedString(string: "•\t", attributes: listAttributes) : nil
+            }
+            if line.hasPrefix("\u{FFFC}" + sep) {
+                return hasContent(after: "\u{FFFC}" + sep) ? checkboxMarker(checked: false) : nil
+            }
+        }
+        // Numbered: "N.<tab>" continues as "N+1.<tab>".
+        if let tab = line.firstIndex(of: "\t"), line[..<tab].hasSuffix("."),
+           let n = Int(line[..<tab].dropLast()) {
+            return hasContent(after: String(line[...tab]))
+                ? NSAttributedString(string: "\(n + 1).\t", attributes: listAttributes) : nil
         }
         return nil
     }

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -374,10 +374,13 @@ private final class LinkPasteTextView: NSTextView {
         case "-":
             replace(prefixRange, with: NSAttributedString(string: "•\u{00A0}", attributes: bodyAttributes))
             return true
-        case "- [", "- [ ]", "- []":
+        // "- " already became a bullet by the time "[ ]" is typed, so the
+        // checkbox forms chain off the bullet: "• [" + space completes it.
+        case "- [", "- [ ]", "- []",
+             "•\u{00A0}[", "•\u{00A0}[ ]", "•\u{00A0}[]":
             replace(prefixRange, with: NSAttributedString(string: "☐\u{00A0}", attributes: bodyAttributes))
             return true
-        case "- [x]", "- [X]":
+        case "- [x]", "- [X]", "•\u{00A0}[x]", "•\u{00A0}[X]":
             replace(prefixRange, with: NSAttributedString(string: "☑\u{00A0}", attributes: bodyAttributes))
             return true
         case "#", "##", "###":

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -341,12 +341,18 @@ private final class LinkPasteTextView: NSTextView {
     func applyCheckboxCursors() {
         guard let storage = textStorage else { return }
         let ns = storage.string as NSString
+        // Twice the body size: the glyph is a tap target, not a character.
+        let size = defaultFont.pointSize * 2
+        let glyphFont = NSFont(descriptor: defaultFont.fontDescriptor, size: size)
+            ?? NSFont.systemFont(ofSize: size)
         var idx = 0
         while idx < ns.length {
             let ch = ns.substring(with: NSRange(location: idx, length: 1))
             if ch == "☐" || ch == "☑" {
-                storage.addAttribute(.cursor, value: NSCursor.pointingHand,
-                                     range: NSRange(location: idx, length: 1))
+                storage.addAttributes(
+                    [.cursor: NSCursor.pointingHand, .font: glyphFont],
+                    range: NSRange(location: idx, length: 1)
+                )
             }
             idx += 1
         }
@@ -370,6 +376,10 @@ private final class LinkPasteTextView: NSTextView {
         if str == " ", convertLinePrefix() { return }
 
         if str == "\n" {
+            // Enter with the cursor inside a link opens it instead of
+            // breaking the line. Strictly inside: at the link's trailing
+            // edge, return still makes a newline so writing can continue.
+            if openLinkAtCursorInstead() { return }
             // Enter on an empty bullet/checkbox line ends the list: the
             // marker disappears instead of a new one being created.
             if removeBareListMarker() { return }
@@ -421,6 +431,23 @@ private final class LinkPasteTextView: NSTextView {
         default:
             return false
         }
+    }
+
+    /// Pressing return inside a link's text opens the link. Both neighbors
+    /// of the insertion point must carry the same link, so the boundaries
+    /// (just before or just after the link) still insert a newline.
+    private func openLinkAtCursorInstead() -> Bool {
+        guard selectedRange().length == 0, let storage = textStorage else { return false }
+        let loc = selectedRange().location
+        guard loc > 0, loc < storage.length,
+              let before = storage.attribute(.link, at: loc - 1, effectiveRange: nil),
+              let after = storage.attribute(.link, at: loc, effectiveRange: nil)
+        else { return false }
+        let a = (after as? URL)?.absoluteString ?? (after as? String ?? "")
+        let b = (before as? URL)?.absoluteString ?? (before as? String ?? "")
+        guard !a.isEmpty, a == b, let url = URL(string: a) else { return false }
+        NSWorkspace.shared.open(url)
+        return true
     }
 
     /// A line whose full content is "- " becomes a bullet the moment a

--- a/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/StickyNoteWidget.swift
@@ -404,38 +404,55 @@ private final class LinkPasteTextView: NSTextView {
 
     /// Shared rhythm for body, bullet and checkbox lines.
     private var bodyParagraph: NSParagraphStyle {
-        paragraphStyle(isHeading: false, isList: false, isBullet: false, level: 0)
+        paragraphStyle(isHeading: false, isList: false, markerInset: 0, level: 0)
     }
 
-    /// Column where list text begins; markers sit before a tab.
-    private var listTextIndent: CGFloat { (defaultFont.pointSize * 1.8).rounded() }
+    /// Column where list text begins; markers sit before a tab. Wide
+    /// enough for a two-digit number and its dot, whatever the note font —
+    /// a marker wider than its column would push the tab a full extra
+    /// column to the right.
+    private var listTextIndent: CGFloat {
+        let twoDigits = ("88." as NSString).size(withAttributes: [.font: defaultFont]).width
+        return max((defaultFont.pointSize * 1.8).rounded(),
+                   (twoDigits + defaultFont.pointSize * 0.5).rounded())
+    }
 
     /// One Tab/Shift-Tab step — the width of the list column, so nested
     /// list text lands exactly one column further in.
     private var indentStep: CGFloat { listTextIndent }
     private let maxIndentLevel = 6
 
-    /// Narrow bullets get inset so they sit centered under the wider
-    /// checkbox column instead of hugging the left edge.
-    private var bulletInset: CGFloat {
-        let bulletWidth = ("•" as NSString).size(withAttributes: [.font: defaultFont]).width
-        return max(0, ((defaultFont.pointSize * 1.2 - bulletWidth) / 2).rounded())
+    /// Markers right-align to a shared edge just before the text column:
+    /// number dots line up regardless of digit count, the checkbox's right
+    /// side sits on that edge, and the narrow bullet is centered over the
+    /// checkbox. Keeps every marker close to its text.
+    private func markerInset(for line: String) -> CGFloat {
+        let columnEnd = listTextIndent - defaultFont.pointSize * 0.45
+        let boxWidth = defaultFont.pointSize * 1.2
+        if line.hasPrefix("\u{FFFC}\t") { return max(0, (columnEnd - boxWidth).rounded()) }
+        if line.hasPrefix("•\t") {
+            let bulletWidth = ("•" as NSString).size(withAttributes: [.font: defaultFont]).width
+            return max(0, (columnEnd - boxWidth + (boxWidth - bulletWidth) / 2).rounded())
+        }
+        guard let tab = line.firstIndex(of: "\t") else { return 0 }
+        let width = (String(line[..<tab]) as NSString).size(withAttributes: [.font: defaultFont]).width
+        return max(0, (columnEnd - width).rounded())
     }
 
     private var listParagraph: NSParagraphStyle {
-        paragraphStyle(isHeading: false, isList: true, isBullet: false, level: 0)
+        paragraphStyle(isHeading: false, isList: true, markerInset: 0, level: 0)
     }
 
     /// Headings breathe a little more, especially above.
     private var headingParagraph: NSParagraphStyle {
-        paragraphStyle(isHeading: true, isList: false, isBullet: false, level: 0)
+        paragraphStyle(isHeading: true, isList: false, markerInset: 0, level: 0)
     }
 
     /// Single source of paragraph geometry: spacing rhythm per line kind
     /// plus the Tab/Shift-Tab indent level. List lines keep one shared
     /// text column (marker, tab, text) shifted right per level, with
     /// wrapped lines hanging under the text.
-    private func paragraphStyle(isHeading: Bool, isList: Bool, isBullet: Bool, level: Int) -> NSParagraphStyle {
+    private func paragraphStyle(isHeading: Bool, isList: Bool, markerInset: CGFloat, level: Int) -> NSParagraphStyle {
         let p = NSMutableParagraphStyle()
         let indent = CGFloat(level) * indentStep
         if isHeading {
@@ -445,7 +462,7 @@ private final class LinkPasteTextView: NSTextView {
             p.headIndent = indent
         } else if isList {
             p.paragraphSpacing = defaultFont.pointSize * 0.22
-            p.firstLineHeadIndent = indent + (isBullet ? bulletInset : 0)
+            p.firstLineHeadIndent = indent + markerInset
             p.tabStops = [NSTextTab(textAlignment: .left, location: indent + listTextIndent)]
             p.defaultTabInterval = listTextIndent
             p.headIndent = indent + listTextIndent
@@ -485,7 +502,7 @@ private final class LinkPasteTextView: NSTextView {
 
     private func listAttributes(level: Int) -> [NSAttributedString.Key: Any] {
         var a = bodyAttributes
-        a[.paragraphStyle] = paragraphStyle(isHeading: false, isList: true, isBullet: false, level: level)
+        a[.paragraphStyle] = paragraphStyle(isHeading: false, isList: true, markerInset: 0, level: level)
         return a
     }
 
@@ -535,7 +552,7 @@ private final class LinkPasteTextView: NSTextView {
         let s = NSMutableAttributedString(attributedString: checkboxOnly(checked: checked))
         s.append(NSAttributedString(string: "\t", attributes: listAttributes(level: level)))
         s.addAttribute(.paragraphStyle,
-                       value: paragraphStyle(isHeading: false, isList: true, isBullet: false, level: level),
+                       value: paragraphStyle(isHeading: false, isList: true, markerInset: 0, level: level),
                        range: NSRange(location: 0, length: s.length))
         return s
     }
@@ -599,7 +616,7 @@ private final class LinkPasteTextView: NSTextView {
             let style = paragraphStyle(
                 isHeading: !isList && (firstFont?.pointSize ?? 0) > headingThreshold,
                 isList: isList,
-                isBullet: line.hasPrefix("•\t"),
+                markerInset: markerInset(for: line),
                 level: indentLevel(of: existing, isList: isList)
             )
             storage.addAttribute(.paragraphStyle, value: style, range: paragraph)
@@ -710,7 +727,7 @@ private final class LinkPasteTextView: NSTextView {
         guard lines.length > 0 else {
             let existing = typingAttributes[.paragraphStyle] as? NSParagraphStyle
             let level = max(0, min(maxIndentLevel, indentLevel(of: existing, isList: false) + delta))
-            typingAttributes[.paragraphStyle] = paragraphStyle(isHeading: false, isList: false, isBullet: false, level: level)
+            typingAttributes[.paragraphStyle] = paragraphStyle(isHeading: false, isList: false, markerInset: 0, level: level)
             return
         }
         guard shouldChangeText(in: lines, replacementString: nil) else { return }
@@ -726,7 +743,7 @@ private final class LinkPasteTextView: NSTextView {
             storage.addAttribute(.paragraphStyle, value: paragraphStyle(
                 isHeading: !isList && (firstFont?.pointSize ?? 0) > defaultFont.pointSize * 1.1,
                 isList: isList,
-                isBullet: line.hasPrefix("•\t"),
+                markerInset: markerInset(for: line),
                 level: level
             ), range: paragraph)
             location = paragraph.location + paragraph.length

--- a/Sources/EdgeControl/Widgets/Info/WeatherWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/WeatherWidget.swift
@@ -26,7 +26,9 @@ public final class WeatherWidget: DashboardWidget {
         WeatherWidgetBody(
             service: service,
             showForecast: config.bool("showForecast", default: true),
-            isCompact: size.height <= 3
+            // Minimum size is 4x4, so the compact layout must trigger at 4 or
+            // it never renders; the full 64pt/72pt layout needs 5+ rows.
+            isCompact: size.height <= 4
         )
     }
 }

--- a/Sources/EdgeControl/Widgets/Info/WorldClocksWidget.swift
+++ b/Sources/EdgeControl/Widgets/Info/WorldClocksWidget.swift
@@ -18,10 +18,17 @@ public final class WorldClocksWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        WorldClocksWidgetView(
+        let maxByWidth = size.width >= 8 ? 3 : 2
+        // Card rows the placement can hold: grid rows are ~120px, a clock card
+        // plus grid spacing is ~88px, and header/padding overhead is ~60px.
+        let rowsThatFit = max(1, (size.height * 120 - 60) / 88)
+        // Fewer columns on tall placements so the 6 clocks span the height
+        // instead of top-stacking; integer ceiling of 6 / rowsThatFit.
+        let columns = min(maxByWidth, max(1, (6 + rowsThatFit - 1) / rowsThatFit))
+        return WorldClocksWidgetView(
             use24h: config.bool("use24h", default: true),
             isCompact: size.height <= 2,
-            columns: size.width >= 8 ? 3 : 2
+            columns: columns
         )
     }
 }
@@ -50,18 +57,35 @@ private struct WorldClocksWidgetView: View {
                 WidgetHeader(title: "WORLD CLOCKS", color: Theme.widgetPrimary("world-clocks", ts: ts, default: .cyan))
             }
 
-            let cols = Array(repeating: GridItem(.flexible(), spacing: 8), count: columns)
-            LazyVGrid(columns: cols, spacing: 8) {
-                ForEach(worldClocks, id: \.tz) { clock in
-                    clockCard(clock)
+            // Explicit rows instead of LazyVGrid: grid rows hug their content,
+            // which top-stacks the cards and leaves dead space on tall
+            // placements. Stretching each row distributes the leftover height.
+            VStack(spacing: 8) {
+                ForEach(Array(clockRows.enumerated()), id: \.offset) { _, row in
+                    HStack(spacing: 8) {
+                        ForEach(row, id: \.tz) { clock in
+                            clockCard(clock)
+                        }
+                        if row.count < columns {
+                            ForEach(0..<(columns - row.count), id: \.self) { _ in
+                                Color.clear.frame(maxWidth: .infinity)
+                            }
+                        }
+                    }
+                    .frame(maxHeight: .infinity)
                 }
             }
-
-            Spacer(minLength: 0)
+            .frame(maxHeight: .infinity)
         }
         .padding(isCompact ? Theme.compactPadding : Theme.widgetPadding)
         .widgetCard()
         .onReceive(timer) { now = $0 }
+    }
+
+    private var clockRows: [[(city: String, tz: String, flag: String)]] {
+        stride(from: 0, to: worldClocks.count, by: columns).map {
+            Array(worldClocks[$0..<min($0 + columns, worldClocks.count)])
+        }
     }
 
     private func clockCard(_ clock: (city: String, tz: String, flag: String)) -> some View {
@@ -85,7 +109,7 @@ private struct WorldClocksWidgetView: View {
                 .foregroundStyle(.white)
                 .monospacedDigit()
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.vertical, isCompact ? 4 : 8)
         .background(Color.white.opacity(0.03), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }

--- a/Sources/EdgeControl/Widgets/Media/AudioDevicesWidget.swift
+++ b/Sources/EdgeControl/Widgets/Media/AudioDevicesWidget.swift
@@ -7,7 +7,7 @@ public final class AudioDevicesWidget: DashboardWidget {
     public let iconName = "speaker.wave.2"
     public let category: WidgetCategory = .media
     public let requiredServices: Set<ServiceKey> = [.audio]
-    public let supportedSizes = WidgetSizeRange(min: .size(3, 2), max: .size(6, 4))
+    public let supportedSizes = WidgetSizeRange(min: .size(3, 1), max: .size(6, 4))
     public let defaultSize = WidgetSize.size(4, 3)
 
     public let configSchema: [ConfigSchemaEntry] = [

--- a/Sources/EdgeControl/Widgets/Network/BluetoothWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/BluetoothWidget.swift
@@ -70,33 +70,17 @@ private struct BluetoothWidgetView: View {
                     .frame(maxWidth: .infinity)
                 Spacer()
             } else {
-                ForEach(connectedDevices) { device in
-                    HStack(spacing: 8) {
-                        Image(systemName: device.icon)
-                            .font(.system(size: (isCompact ? 14 : 18) * ts.fontScale))
-                            .foregroundStyle(Theme.widgetPrimary("bluetooth", ts: ts, default: .blue))
-                            .frame(width: 24)
-
-                        Text(device.name)
-                            .font(Theme.body(ts))
-                            .foregroundStyle(Theme.text1(ts))
-                            .lineLimit(1)
-
-                        Spacer()
-
-                        if showBattery, let battery = device.batteryLevel {
-                            HStack(spacing: 4) {
-                                Image(systemName: batteryIcon(battery))
-                                    .font(.system(size: 14 * ts.fontScale))
-                                    .foregroundStyle(batteryColor(battery))
-                                Text("\(battery)%")
-                                    .font(Theme.label(ts))
-                                    .foregroundStyle(batteryColor(battery))
-                                    .monospacedDigit()
+                // Overflow scrolls; a short list centers in the viewport via
+                // minHeight so the card doesn't end in a void under the rows.
+                GeometryReader { geo in
+                    TouchScrollView {
+                        VStack(spacing: 0) {
+                            ForEach(connectedDevices) { device in
+                                deviceRow(device)
                             }
                         }
+                        .frame(minHeight: geo.size.height, alignment: .center)
                     }
-                    .padding(.vertical, 4)
                 }
             }
 
@@ -104,6 +88,35 @@ private struct BluetoothWidgetView: View {
         }
         .padding(isCompact ? Theme.compactPadding : Theme.widgetPadding)
         .widgetCard()
+    }
+
+    private func deviceRow(_ device: BTDevice) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: device.icon)
+                .font(.system(size: (isCompact ? 14 : 18) * ts.fontScale))
+                .foregroundStyle(Theme.widgetPrimary("bluetooth", ts: ts, default: .blue))
+                .frame(width: 24)
+
+            Text(device.name)
+                .font(Theme.body(ts))
+                .foregroundStyle(Theme.text1(ts))
+                .lineLimit(1)
+
+            Spacer()
+
+            if showBattery, let battery = device.batteryLevel {
+                HStack(spacing: 4) {
+                    Image(systemName: batteryIcon(battery))
+                        .font(.system(size: 14 * ts.fontScale))
+                        .foregroundStyle(batteryColor(battery))
+                    Text("\(battery)%")
+                        .font(Theme.label(ts))
+                        .foregroundStyle(batteryColor(battery))
+                        .monospacedDigit()
+                }
+            }
+        }
+        .padding(.vertical, 4)
     }
 
     private func batteryIcon(_ level: Int) -> String {

--- a/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
@@ -25,6 +25,7 @@ public final class NetworkStatsWidget: DashboardWidget {
             service: service,
             isCompact: size.height <= 2,
             isBar: size.height <= 1,
+            showTitle: size.width >= 3,
             showCompactTotals: size.width >= 5 && size.height >= 2
         )
     }
@@ -37,6 +38,9 @@ private struct NetworkStatsWidgetView: View {
     // Single grid row: the stacked DOWN/UP rows would overflow ~112px of
     // interior height at larger font scales, so render them side by side.
     let isBar: Bool
+    // Keep the widget's name visible wherever it fits — full header down to
+    // 2 rows, a bare caption in the 1-row layout — matching Disk I/O.
+    let showTitle: Bool
     // Wide-and-tall compact (width >= 5, height >= 2) has room for the
     // DL/UL totals row; the 1-row bar layout never does.
     let showCompactTotals: Bool
@@ -46,8 +50,13 @@ private struct NetworkStatsWidgetView: View {
         let secondary = Theme.widgetSecondary("network-stats", ts: ts, default: .cyan) ?? Theme.accentCyan
 
         VStack(spacing: isCompact ? 6 : 12) {
-            if !isCompact {
+            if !isCompact || (showTitle && !isBar) {
                 WidgetHeader(title: "NETWORK", color: primary)
+            } else if showTitle {
+                Text("NETWORK")
+                    .font(Theme.caption(ts))
+                    .foregroundStyle(Theme.text3(ts))
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             if !isBar { Spacer(minLength: 0) }

--- a/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
@@ -7,7 +7,7 @@ public final class NetworkStatsWidget: DashboardWidget {
     public let iconName = "network"
     public let category: WidgetCategory = .network
     public let requiredServices: Set<ServiceKey> = [.network]
-    public let supportedSizes = WidgetSizeRange(min: .size(3, 2), max: .size(8, 4))
+    public let supportedSizes = WidgetSizeRange(min: .size(3, 1), max: .size(8, 4))
     public let defaultSize = WidgetSize.size(4, 3)
 
     public let configSchema: [ConfigSchemaEntry] = []
@@ -21,7 +21,7 @@ public final class NetworkStatsWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        NetworkStatsWidgetView(service: service, isCompact: size.height <= 2)
+        NetworkStatsWidgetView(service: service, isCompact: size.height <= 2, isBar: size.height <= 1)
     }
 }
 
@@ -29,6 +29,9 @@ private struct NetworkStatsWidgetView: View {
     @ObservedObject var service: NetworkMonitorService
     @Environment(\.themeSettings) private var ts
     let isCompact: Bool
+    // Single grid row: the stacked DOWN/UP rows would overflow ~112px of
+    // interior height at larger font scales, so render them side by side.
+    let isBar: Bool
 
     var body: some View {
         let primary = Theme.widgetPrimary("network-stats", ts: ts, default: .green)
@@ -39,38 +42,18 @@ private struct NetworkStatsWidgetView: View {
                 WidgetHeader(title: "NETWORK", color: primary)
             }
 
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 4) {
-                    Image(systemName: "arrow.down.circle.fill")
-                        .font(.system(size: (isCompact ? 14 : 20) * ts.fontScale))
-                        .foregroundStyle(primary)
-                    Text("DOWN")
-                        .font(Theme.label(ts))
-                        .foregroundStyle(Theme.text3(ts))
-                    Spacer()
-                    Text(NetworkMonitorService.formatSpeed(service.downloadSpeed))
-                        .font(Theme.value(ts))
-                        .foregroundStyle(Theme.text1(ts))
-                        .monospacedDigit()
-                        .minimumScaleFactor(0.5)
+            if isBar {
+                HStack(spacing: 12) {
+                    barGroup(icon: "arrow.down.circle.fill", color: primary,
+                             speed: service.downloadSpeed)
+                    barGroup(icon: "arrow.up.circle.fill", color: secondary,
+                             speed: service.uploadSpeed)
                 }
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 4) {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.system(size: (isCompact ? 14 : 20) * ts.fontScale))
-                        .foregroundStyle(secondary)
-                    Text("UP")
-                        .font(Theme.label(ts))
-                        .foregroundStyle(Theme.text3(ts))
-                    Spacer()
-                    Text(NetworkMonitorService.formatSpeed(service.uploadSpeed))
-                        .font(Theme.value(ts))
-                        .foregroundStyle(Theme.text1(ts))
-                        .monospacedDigit()
-                        .minimumScaleFactor(0.5)
-                }
+            } else {
+                speedRow(icon: "arrow.down.circle.fill", color: primary,
+                         label: "DOWN", speed: service.downloadSpeed)
+                speedRow(icon: "arrow.up.circle.fill", color: secondary,
+                         label: "UP", speed: service.uploadSpeed)
             }
 
             if !isCompact {
@@ -84,6 +67,38 @@ private struct NetworkStatsWidgetView: View {
         }
         .padding(isCompact ? Theme.compactPadding : Theme.widgetPadding)
         .widgetCard()
+    }
+
+    private func speedRow(icon: String, color: Color, label: String, speed: Double) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: (isCompact ? 14 : 20) * ts.fontScale))
+                .foregroundStyle(color)
+            Text(label)
+                .font(Theme.label(ts))
+                .foregroundStyle(Theme.text3(ts))
+            Spacer()
+            Text(NetworkMonitorService.formatSpeed(speed))
+                .font(Theme.value(ts))
+                .foregroundStyle(Theme.text1(ts))
+                .monospacedDigit()
+                .minimumScaleFactor(0.5)
+        }
+    }
+
+    private func barGroup(icon: String, color: Color, speed: Double) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 14 * ts.fontScale))
+                .foregroundStyle(color)
+            Text(NetworkMonitorService.formatSpeed(speed))
+                .font(Theme.value(ts))
+                .foregroundStyle(Theme.text1(ts))
+                .monospacedDigit()
+                .minimumScaleFactor(0.5)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func totalChip(_ label: String, value: String, color: Color) -> some View {

--- a/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
@@ -25,7 +25,7 @@ public final class NetworkStatsWidget: DashboardWidget {
             service: service,
             isCompact: size.height <= 2,
             isBar: size.height <= 1,
-            showTitle: size.width >= 3,
+            showTitle: true,
             showCompactTotals: size.width >= 5 && size.height >= 2
         )
     }

--- a/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
@@ -50,19 +50,22 @@ private struct NetworkStatsWidgetView: View {
                 WidgetHeader(title: "NETWORK", color: primary)
             }
 
-            if isBar {
-                HStack(spacing: 12) {
-                    barGroup(icon: "arrow.down.circle.fill", color: primary,
-                             label: "DOWN", speed: service.downloadSpeed)
-                    barGroup(icon: "arrow.up.circle.fill", color: secondary,
-                             label: "UP", speed: service.uploadSpeed)
-                }
-            } else {
-                speedRow(icon: "arrow.down.circle.fill", color: primary,
-                         label: "DOWN", speed: service.downloadSpeed)
-                speedRow(icon: "arrow.up.circle.fill", color: secondary,
-                         label: "UP", speed: service.uploadSpeed)
-            }
+            if !isBar { Spacer(minLength: 0) }
+
+            // Same component Disk I/O renders — equal boxes, equal layout.
+            RatePairView(
+                first: .init(
+                    icon: "arrow.down.circle.fill", label: "DOWN",
+                    value: NetworkMonitorService.formatSpeed(service.downloadSpeed),
+                    color: primary
+                ),
+                second: .init(
+                    icon: "arrow.up.circle.fill", label: "UP",
+                    value: NetworkMonitorService.formatSpeed(service.uploadSpeed),
+                    color: secondary
+                ),
+                compact: isCompact
+            )
 
             if !isBar && (!isCompact || showCompactTotals) {
                 HStack(spacing: 10) {
@@ -77,44 +80,7 @@ private struct NetworkStatsWidgetView: View {
         .widgetCard()
     }
 
-    private func speedRow(icon: String, color: Color, label: String, speed: Double) -> some View {
-        HStack(spacing: 4) {
-            Image(systemName: icon)
-                .font(.system(size: (isCompact ? 14 : 20) * ts.fontScale))
-                .foregroundStyle(color)
-            Text(label)
-                .font(Theme.label(ts))
-                .foregroundStyle(Theme.text3(ts))
-            Spacer()
-            Text(NetworkMonitorService.formatSpeed(speed))
-                .font(Theme.value(ts))
-                .foregroundStyle(Theme.text1(ts))
-                .monospacedDigit()
-                .minimumScaleFactor(0.5)
-        }
-    }
 
-    // 1-row group: icon+label line over the value line, matching Disk I/O's
-    // single-row arrangement so the two widgets read as one family.
-    private func barGroup(icon: String, color: Color, label: String, speed: Double) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 4) {
-                Image(systemName: icon)
-                    .font(.system(size: 12 * ts.fontScale))
-                    .foregroundStyle(color)
-                Text(label)
-                    .font(Theme.label(ts))
-                    .foregroundStyle(Theme.text3(ts))
-            }
-            Text(NetworkMonitorService.formatSpeed(speed))
-                .font(Theme.value(ts))
-                .foregroundStyle(Theme.text1(ts))
-                .monospacedDigit()
-                .minimumScaleFactor(0.5)
-                .lineLimit(1)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
 
     private func totalChip(_ label: String, value: String, color: Color) -> some View {
         HStack(spacing: 6) {

--- a/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
@@ -53,9 +53,9 @@ private struct NetworkStatsWidgetView: View {
             if isBar {
                 HStack(spacing: 12) {
                     barGroup(icon: "arrow.down.circle.fill", color: primary,
-                             speed: service.downloadSpeed)
+                             label: "DOWN", speed: service.downloadSpeed)
                     barGroup(icon: "arrow.up.circle.fill", color: secondary,
-                             speed: service.uploadSpeed)
+                             label: "UP", speed: service.uploadSpeed)
                 }
             } else {
                 speedRow(icon: "arrow.down.circle.fill", color: primary,
@@ -94,11 +94,18 @@ private struct NetworkStatsWidgetView: View {
         }
     }
 
-    private func barGroup(icon: String, color: Color, speed: Double) -> some View {
-        HStack(spacing: 4) {
-            Image(systemName: icon)
-                .font(.system(size: 14 * ts.fontScale))
-                .foregroundStyle(color)
+    // 1-row group: icon+label line over the value line, matching Disk I/O's
+    // single-row arrangement so the two widgets read as one family.
+    private func barGroup(icon: String, color: Color, label: String, speed: Double) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 12 * ts.fontScale))
+                    .foregroundStyle(color)
+                Text(label)
+                    .font(Theme.label(ts))
+                    .foregroundStyle(Theme.text3(ts))
+            }
             Text(NetworkMonitorService.formatSpeed(speed))
                 .font(Theme.value(ts))
                 .foregroundStyle(Theme.text1(ts))

--- a/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
@@ -56,10 +56,9 @@ private struct NetworkStatsWidgetView: View {
             if (!isCompact || (showTitle && !isBar)) && !isNarrow {
                 WidgetHeader(title: "NETWORK", color: primary)
             } else if showTitle {
-                Text("NETWORK")
+                Text(isNarrow ? "NET" : "NETWORK")
                     .font(Theme.caption(ts))
                     .foregroundStyle(Theme.text3(ts))
-                    .minimumScaleFactor(0.6)
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }

--- a/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
@@ -7,7 +7,7 @@ public final class NetworkStatsWidget: DashboardWidget {
     public let iconName = "network"
     public let category: WidgetCategory = .network
     public let requiredServices: Set<ServiceKey> = [.network]
-    public let supportedSizes = WidgetSizeRange(min: .size(3, 1), max: .size(8, 4))
+    public let supportedSizes = WidgetSizeRange(min: .size(1, 1), max: .size(8, 4))
     public let defaultSize = WidgetSize.size(4, 3)
 
     public let configSchema: [ConfigSchemaEntry] = []
@@ -25,6 +25,7 @@ public final class NetworkStatsWidget: DashboardWidget {
             service: service,
             isCompact: size.height <= 2,
             isBar: size.height <= 1,
+            isNarrow: size.width <= 1,
             showTitle: true,
             showCompactTotals: size.width >= 5 && size.height >= 2
         )
@@ -38,6 +39,8 @@ private struct NetworkStatsWidgetView: View {
     // Single grid row: the stacked DOWN/UP rows would overflow ~112px of
     // interior height at larger font scales, so render them side by side.
     let isBar: Bool
+    // One grid column: stacked groups under a slim caption.
+    let isNarrow: Bool
     // Keep the widget's name visible wherever it fits — full header down to
     // 2 rows, a bare caption in the 1-row layout — matching Disk I/O.
     let showTitle: Bool
@@ -50,12 +53,14 @@ private struct NetworkStatsWidgetView: View {
         let secondary = Theme.widgetSecondary("network-stats", ts: ts, default: .cyan) ?? Theme.accentCyan
 
         VStack(spacing: isCompact ? 6 : 12) {
-            if !isCompact || (showTitle && !isBar) {
+            if (!isCompact || (showTitle && !isBar)) && !isNarrow {
                 WidgetHeader(title: "NETWORK", color: primary)
             } else if showTitle {
                 Text("NETWORK")
                     .font(Theme.caption(ts))
                     .foregroundStyle(Theme.text3(ts))
+                    .minimumScaleFactor(0.6)
+                    .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
@@ -73,7 +78,8 @@ private struct NetworkStatsWidgetView: View {
                     value: NetworkMonitorService.formatSpeed(service.uploadSpeed),
                     color: secondary
                 ),
-                compact: isCompact
+                compact: isCompact,
+                vertical: isNarrow
             )
 
             if !isBar && (!isCompact || showCompactTotals) {

--- a/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
@@ -59,7 +59,7 @@ private struct NetworkStatsWidgetView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            if !isBar { Spacer(minLength: 0) }
+            Spacer(minLength: 0)
 
             // Same component Disk I/O renders — equal boxes, equal layout.
             RatePairView(

--- a/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/NetworkStatsWidget.swift
@@ -21,7 +21,12 @@ public final class NetworkStatsWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        NetworkStatsWidgetView(service: service, isCompact: size.height <= 2, isBar: size.height <= 1)
+        NetworkStatsWidgetView(
+            service: service,
+            isCompact: size.height <= 2,
+            isBar: size.height <= 1,
+            showCompactTotals: size.width >= 5 && size.height >= 2
+        )
     }
 }
 
@@ -32,6 +37,9 @@ private struct NetworkStatsWidgetView: View {
     // Single grid row: the stacked DOWN/UP rows would overflow ~112px of
     // interior height at larger font scales, so render them side by side.
     let isBar: Bool
+    // Wide-and-tall compact (width >= 5, height >= 2) has room for the
+    // DL/UL totals row; the 1-row bar layout never does.
+    let showCompactTotals: Bool
 
     var body: some View {
         let primary = Theme.widgetPrimary("network-stats", ts: ts, default: .green)
@@ -56,7 +64,7 @@ private struct NetworkStatsWidgetView: View {
                          label: "UP", speed: service.uploadSpeed)
             }
 
-            if !isCompact {
+            if !isBar && (!isCompact || showCompactTotals) {
                 HStack(spacing: 10) {
                     totalChip("DL", value: NetworkMonitorService.formatBytes(service.totalDownloaded), color: primary)
                     totalChip("UL", value: NetworkMonitorService.formatBytes(service.totalUploaded), color: secondary)

--- a/Sources/EdgeControl/Widgets/Network/WiFiInfoWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/WiFiInfoWidget.swift
@@ -7,7 +7,7 @@ public final class WiFiInfoWidget: DashboardWidget {
     public let iconName = "wifi"
     public let category: WidgetCategory = .network
     public let requiredServices: Set<ServiceKey> = [.wifi]
-    public let supportedSizes = WidgetSizeRange(min: .size(3, 2), max: .size(6, 4))
+    public let supportedSizes = WidgetSizeRange(min: .size(3, 1), max: .size(6, 4))
     public let defaultSize = WidgetSize.size(4, 3)
 
     public let configSchema: [ConfigSchemaEntry] = []

--- a/Sources/EdgeControl/Widgets/Network/WiFiInfoWidget.swift
+++ b/Sources/EdgeControl/Widgets/Network/WiFiInfoWidget.swift
@@ -21,7 +21,11 @@ public final class WiFiInfoWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        WiFiInfoWidgetView(service: service, isCompact: size.height <= 2)
+        WiFiInfoWidgetView(
+            service: service,
+            isCompact: size.height <= 2,
+            showInlineChips: size.width >= 5
+        )
     }
 }
 
@@ -29,6 +33,8 @@ private struct WiFiInfoWidgetView: View {
     @ObservedObject var service: WiFiService
     @Environment(\.themeSettings) private var ts
     let isCompact: Bool
+    // Wide compact cells (width >= 5) keep SPEED/CH inline next to the SSID.
+    let showInlineChips: Bool
 
     var body: some View {
         VStack(alignment: .leading, spacing: isCompact ? 6 : 10) {
@@ -50,11 +56,21 @@ private struct WiFiInfoWidgetView: View {
             }
 
             if service.isConnected {
-                Text(service.ssid ?? "Unknown")
-                    .font(Theme.value(ts))
-                    .foregroundStyle(Theme.text1(ts))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.6)
+                HStack(alignment: .firstTextBaseline, spacing: 12) {
+                    Text(service.ssid ?? "Unknown")
+                        .font(Theme.value(ts))
+                        .foregroundStyle(Theme.text1(ts))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+
+                    // Inline single-line chips share the SSID row, so they
+                    // add no height a 1-2 row cell can't afford.
+                    if isCompact && showInlineChips {
+                        Spacer(minLength: 8)
+                        inlineChip("SPEED", value: String(format: "%.0f Mbps", service.txRate))
+                        inlineChip("CH", value: "\(service.channel)")
+                    }
+                }
 
                 if !isCompact {
                     HStack(spacing: 12) {
@@ -96,6 +112,19 @@ private struct WiFiInfoWidgetView: View {
         else if rssi > -70 { strength = 2 }
         else { strength = 1 }
         return index < strength ? Theme.widgetPrimary("wifi-info", ts: ts, default: .green) : Color.white.opacity(0.1)
+    }
+
+    private func inlineChip(_ label: String, value: String) -> some View {
+        HStack(spacing: 4) {
+            Text(label)
+                .font(Theme.caption(ts))
+                .foregroundStyle(Theme.text3(ts))
+            Text(value)
+                .font(Theme.body(ts))
+                .foregroundStyle(Theme.text1(ts))
+                .monospacedDigit()
+                .lineLimit(1)
+        }
     }
 
     private func detailChip(_ label: String, value: String) -> some View {

--- a/Sources/EdgeControl/Widgets/Plugin/PluginWebWidget.swift
+++ b/Sources/EdgeControl/Widgets/Plugin/PluginWebWidget.swift
@@ -816,9 +816,14 @@ private struct PluginWebViewRepresentable: NSViewRepresentable {
 
             Task {
                 let center = UNUserNotificationCenter.current()
-                let settings = await center.notificationSettings()
+                // UNNotificationSettings is not Sendable, so extract the one
+                // needed value via the completion-handler API instead of
+                // sending the settings object across isolation.
+                let status = await withCheckedContinuation { (continuation: CheckedContinuation<UNAuthorizationStatus, Never>) in
+                    center.getNotificationSettings { continuation.resume(returning: $0.authorizationStatus) }
+                }
 
-                switch settings.authorizationStatus {
+                switch status {
                 case .authorized, .provisional:
                     break
                 case .notDetermined:

--- a/Sources/EdgeControl/Widgets/System/CPUCoresWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/CPUCoresWidget.swift
@@ -21,14 +21,31 @@ public final class CPUCoresWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        CPUCoresWidgetView(metricsService: metricsService, columns: size.width >= 8 ? 2 : 1)
+        CPUCoresWidgetView(metricsService: metricsService, size: size)
     }
 }
 
 private struct CPUCoresWidgetView: View {
     @ObservedObject var metricsService: SystemMetricsService
     @Environment(\.themeSettings) private var ts
-    let columns: Int
+    let size: WidgetSize
+
+    // Row geometry: coreRow fixed frame + VStack spacing; header title line + vertical padding.
+    private static let rowHeight: CGFloat = 18
+    private static let rowSpacing: CGFloat = 2
+    private static let headerChrome: CGFloat = 34
+
+    private var columns: Int {
+        let count = metricsService.perCoreUsage.count
+        let available = CGFloat(size.height) * GridConstants.cellHeight - Self.headerChrome
+        let rowsThatFit = max(1, Int((available + Self.rowSpacing) / (Self.rowHeight + Self.rowSpacing)))
+        let maxByWidth = size.width >= 6 ? 2 : 1
+        for cols in 1...maxByWidth where (count + cols - 1) / cols <= rowsThatFit {
+            return cols
+        }
+        // Even maxByWidth columns overflow: keep width-only choice, TouchScrollView scrolls the rest.
+        return size.width >= 8 ? 2 : 1
+    }
 
     private var primary: Color { Theme.widgetPrimary("cpu-cores", ts: ts, default: .purple) }
 

--- a/Sources/EdgeControl/Widgets/System/CPUGaugeWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/CPUGaugeWidget.swift
@@ -49,7 +49,7 @@ private struct CPUGaugeWidgetView: View {
             displayValue: String(format: "%.0f%%", cpu),
             unit: isCompact ? "" : abbreviate(brand),
             accentColor: Theme.widgetPrimary("cpu-gauge", ts: ts, default: .cyan),
-            showLabel: showLabel && !isCompact
+            showLabel: showLabel
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(Theme.compactPadding)

--- a/Sources/EdgeControl/Widgets/System/CPUGaugeWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/CPUGaugeWidget.swift
@@ -47,7 +47,7 @@ private struct CPUGaugeWidgetView: View {
             maxValue: 100,
             label: "CPU",
             displayValue: String(format: "%.0f%%", cpu),
-            unit: isCompact ? "" : abbreviate(brand),
+            unit: abbreviate(brand),
             accentColor: Theme.widgetPrimary("cpu-gauge", ts: ts, default: .cyan),
             showLabel: showLabel
         )

--- a/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
@@ -7,7 +7,7 @@ public final class DiskIOWidget: DashboardWidget {
     public let iconName = "internaldrive"
     public let category: WidgetCategory = .system
     public let requiredServices: Set<ServiceKey> = [.diskIO]
-    public let supportedSizes = WidgetSizeRange(min: .size(3, 2), max: .size(8, 4))
+    public let supportedSizes = WidgetSizeRange(min: .size(2, 1), max: .size(8, 4))
     public let defaultSize = WidgetSize.size(4, 3)
 
     public let configSchema: [ConfigSchemaEntry] = []

--- a/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
@@ -7,7 +7,7 @@ public final class DiskIOWidget: DashboardWidget {
     public let iconName = "internaldrive"
     public let category: WidgetCategory = .system
     public let requiredServices: Set<ServiceKey> = [.diskIO]
-    public let supportedSizes = WidgetSizeRange(min: .size(2, 1), max: .size(8, 4))
+    public let supportedSizes = WidgetSizeRange(min: .size(1, 1), max: .size(8, 4))
     public let defaultSize = WidgetSize.size(4, 3)
 
     public let configSchema: [ConfigSchemaEntry] = []
@@ -21,7 +21,7 @@ public final class DiskIOWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        DiskIOWidgetView(service: service, isCompact: size.height <= 2, showTitle: true, isBar: size.height <= 1)
+        DiskIOWidgetView(service: service, isCompact: size.height <= 2, showTitle: true, isBar: size.height <= 1, isNarrow: size.width <= 1)
     }
 }
 
@@ -33,15 +33,19 @@ private struct DiskIOWidgetView: View {
     // to 2 rows, a bare caption in the 1-row layout.
     let showTitle: Bool
     let isBar: Bool
+    // One grid column: stacked groups under a slim caption.
+    let isNarrow: Bool
 
     var body: some View {
         VStack(spacing: isCompact ? 6 : 12) {
-            if !isCompact || (showTitle && !isBar) {
+            if (!isCompact || (showTitle && !isBar)) && !isNarrow {
                 WidgetHeader(title: "DISK I/O", color: Theme.widgetPrimary("disk-io", ts: ts, default: .blue))
             } else if showTitle {
                 Text("DISK I/O")
                     .font(Theme.caption(ts))
                     .foregroundStyle(Theme.text3(ts))
+                    .minimumScaleFactor(0.6)
+                    .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
@@ -58,7 +62,8 @@ private struct DiskIOWidgetView: View {
                     value: formatSpeed(service.writeBytesPerSec),
                     color: Theme.widgetTertiary("disk-io", ts: ts, default: .orange) ?? Theme.accentOrange
                 ),
-                compact: isCompact
+                compact: isCompact,
+                vertical: isNarrow
             )
 
             Spacer(minLength: 0)

--- a/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
@@ -21,7 +21,7 @@ public final class DiskIOWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        DiskIOWidgetView(service: service, isCompact: size.height <= 2)
+        DiskIOWidgetView(service: service, isCompact: size.height <= 2, showTitle: size.width >= 3, isBar: size.height <= 1)
     }
 }
 
@@ -29,11 +29,20 @@ private struct DiskIOWidgetView: View {
     @ObservedObject var service: DiskIOService
     @Environment(\.themeSettings) private var ts
     let isCompact: Bool
+    // Keep the widget's name visible wherever it fits: the full header down
+    // to 2 rows, a bare caption in the 1-row layout.
+    let showTitle: Bool
+    let isBar: Bool
 
     var body: some View {
         VStack(spacing: isCompact ? 6 : 12) {
-            if !isCompact {
+            if !isCompact || (showTitle && !isBar) {
                 WidgetHeader(title: "DISK I/O", color: Theme.widgetPrimary("disk-io", ts: ts, default: .blue))
+            } else if showTitle {
+                Text("DISK I/O")
+                    .font(Theme.caption(ts))
+                    .foregroundStyle(Theme.text3(ts))
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
 
             Spacer(minLength: 0)

--- a/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
@@ -47,43 +47,19 @@ private struct DiskIOWidgetView: View {
 
             Spacer(minLength: 0)
 
-            HStack(spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "arrow.down.circle.fill")
-                            .font(.system(size: (isCompact ? 14 : 18) * ts.fontScale))
-                            .foregroundStyle(Theme.widgetSecondary("disk-io", ts: ts, default: .green) ?? Theme.accentGreen)
-                        Text("READ")
-                            .font(Theme.label(ts))
-                            .foregroundStyle(Theme.text3(ts))
-                    }
-                    Text(formatSpeed(service.readBytesPerSec))
-                        .font(Theme.value(ts))
-                        .foregroundStyle(Theme.text1(ts))
-                        .monospacedDigit()
-                        .minimumScaleFactor(0.5)
-                        .lineLimit(1)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "arrow.up.circle.fill")
-                            .font(.system(size: (isCompact ? 14 : 18) * ts.fontScale))
-                            .foregroundStyle(Theme.widgetTertiary("disk-io", ts: ts, default: .orange) ?? Theme.accentOrange)
-                        Text("WRITE")
-                            .font(Theme.label(ts))
-                            .foregroundStyle(Theme.text3(ts))
-                    }
-                    Text(formatSpeed(service.writeBytesPerSec))
-                        .font(Theme.value(ts))
-                        .foregroundStyle(Theme.text1(ts))
-                        .monospacedDigit()
-                        .minimumScaleFactor(0.5)
-                        .lineLimit(1)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
+            RatePairView(
+                first: .init(
+                    icon: "arrow.down.circle.fill", label: "READ",
+                    value: formatSpeed(service.readBytesPerSec),
+                    color: Theme.widgetSecondary("disk-io", ts: ts, default: .green) ?? Theme.accentGreen
+                ),
+                second: .init(
+                    icon: "arrow.up.circle.fill", label: "WRITE",
+                    value: formatSpeed(service.writeBytesPerSec),
+                    color: Theme.widgetTertiary("disk-io", ts: ts, default: .orange) ?? Theme.accentOrange
+                ),
+                compact: isCompact
+            )
 
             Spacer(minLength: 0)
         }

--- a/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
@@ -21,7 +21,7 @@ public final class DiskIOWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        DiskIOWidgetView(service: service, isCompact: size.height <= 2, showTitle: size.width >= 3, isBar: size.height <= 1)
+        DiskIOWidgetView(service: service, isCompact: size.height <= 2, showTitle: true, isBar: size.height <= 1)
     }
 }
 

--- a/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
@@ -36,6 +36,8 @@ private struct DiskIOWidgetView: View {
                 WidgetHeader(title: "DISK I/O", color: Theme.widgetPrimary("disk-io", ts: ts, default: .blue))
             }
 
+            Spacer(minLength: 0)
+
             HStack(spacing: 12) {
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 4) {

--- a/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/DiskIOWidget.swift
@@ -41,10 +41,11 @@ private struct DiskIOWidgetView: View {
             if (!isCompact || (showTitle && !isBar)) && !isNarrow {
                 WidgetHeader(title: "DISK I/O", color: Theme.widgetPrimary("disk-io", ts: ts, default: .blue))
             } else if showTitle {
-                Text("DISK I/O")
+                // One column can't fit "DISK I/O" legibly; a short name beats
+                // a microscopic one.
+                Text(isNarrow ? "DISK" : "DISK I/O")
                     .font(Theme.caption(ts))
                     .foregroundStyle(Theme.text3(ts))
-                    .minimumScaleFactor(0.6)
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }

--- a/Sources/EdgeControl/Widgets/System/MemoryGaugeWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/MemoryGaugeWidget.swift
@@ -47,7 +47,6 @@ private struct MemoryGaugeWidgetView: View {
         let totalGB = mem?.memoryTotalGB ?? 0
 
         let unitText: String = {
-            if isCompact { return "" }
             if showUsedGB { return String(format: "%.1f / %.0f GB", usedGB, totalGB) }
             return ""
         }()

--- a/Sources/EdgeControl/Widgets/System/MemoryGaugeWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/MemoryGaugeWidget.swift
@@ -59,7 +59,7 @@ private struct MemoryGaugeWidgetView: View {
             displayValue: String(format: "%.0f%%", percent),
             unit: unitText,
             accentColor: Theme.widgetPrimary("memory-gauge", ts: ts, default: .purple),
-            showLabel: showLabel && !isCompact
+            showLabel: showLabel
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(Theme.compactPadding)

--- a/Sources/EdgeControl/Widgets/System/MemoryPressureWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/MemoryPressureWidget.swift
@@ -60,7 +60,7 @@ private struct MemoryPressureWidgetView: View {
             displayValue: String(format: "%.0f%%", pressure),
             unit: swapText,
             accentColor: primary,
-            showLabel: showLabel && !isCompact
+            showLabel: showLabel
         )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(Theme.compactPadding)

--- a/Sources/EdgeControl/Widgets/System/ProcessListWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/ProcessListWidget.swift
@@ -15,7 +15,7 @@ public final class ProcessListWidget: DashboardWidget {
         ConfigSchemaEntry(key: "sortBy", label: "Sort By", type: .picker, defaultValue: .string("cpu"), options: ["cpu", "memory"]),
         // "auto" fills whatever height the widget has; a number pins the row
         // count and scrolls past it.
-        ConfigSchemaEntry(key: "rows", label: "Rows", type: .picker, defaultValue: .string("auto"), options: ["auto", "4", "6", "8", "10", "12"]),
+        ConfigSchemaEntry(key: "rows", label: "Rows", type: .picker, defaultValue: .string("auto"), options: ["auto", "4", "6", "8", "10", "12", "16"]),
     ]
     public let defaultColors = WidgetColors(primary: .purple, secondary: .cyan)
 
@@ -73,7 +73,7 @@ private struct ProcessListWidgetView: View {
                         .foregroundStyle(Theme.text3(ts))
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    let fitCount = min(max(Int(geo.size.height / rowHeight), 3), 12)
+                    let fitCount = min(max(Int(geo.size.height / rowHeight), 3), 16)
                     let maxCount = fixedRows ?? fitCount
                     let ranked = sortByMemory
                         ? service.topProcesses.sorted { $0.memoryMB > $1.memoryMB }

--- a/Sources/EdgeControl/Widgets/System/ProcessListWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/ProcessListWidget.swift
@@ -24,14 +24,16 @@ public final class ProcessListWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        ProcessListWidgetView(service: service, isCompact: size.height <= 3)
+        ProcessListWidgetView(service: service)
     }
 }
 
 private struct ProcessListWidgetView: View {
     @ObservedObject var service: ProcessMonitorService
     @Environment(\.themeSettings) private var ts
-    let isCompact: Bool
+
+    // Row = 26pt icon + 2x8pt vertical padding + 1pt divider.
+    private let rowHeight: CGFloat = 43
 
     var body: some View {
         VStack(spacing: 0) {
@@ -44,10 +46,8 @@ private struct ProcessListWidgetView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Text("CPU")
                     .frame(width: 70, alignment: .trailing)
-                if !isCompact {
-                    Text("MEM")
-                        .frame(width: 70, alignment: .trailing)
-                }
+                Text("MEM")
+                    .frame(width: 70, alignment: .trailing)
             }
             .font(Theme.label(ts))
             .foregroundStyle(Theme.text3(ts))
@@ -56,22 +56,27 @@ private struct ProcessListWidgetView: View {
 
             Divider().background(Theme.border(ts))
 
-            if service.topProcesses.isEmpty {
-                Text("Loading...")
-                    .font(Theme.body(ts))
-                    .foregroundStyle(Theme.text3(ts))
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                let maxCount = isCompact ? 4 : 8
-                ForEach(Array(service.topProcesses.prefix(maxCount))) { proc in
-                    processRow(proc)
-                    if proc.id != service.topProcesses.prefix(maxCount).last?.id {
-                        Divider().background(Theme.border(ts)).padding(.leading, 50)
+            GeometryReader { geo in
+                if service.topProcesses.isEmpty {
+                    Text("Loading...")
+                        .font(Theme.body(ts))
+                        .foregroundStyle(Theme.text3(ts))
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    // Service publishes at most 5 processes, so cap there rather than 12.
+                    let maxCount = min(max(Int(geo.size.height / rowHeight), 3), 12)
+                    let visible = Array(service.topProcesses.prefix(maxCount))
+                    VStack(spacing: 0) {
+                        ForEach(visible) { proc in
+                            processRow(proc)
+                            if proc.id != visible.last?.id {
+                                Divider().background(Theme.border(ts)).padding(.leading, 50)
+                            }
+                        }
+                        Spacer(minLength: 0)
                     }
                 }
             }
-
-            Spacer(minLength: 0)
         }
         .widgetCard()
     }
@@ -102,13 +107,11 @@ private struct ProcessListWidgetView: View {
                 .monospacedDigit()
                 .frame(width: 70, alignment: .trailing)
 
-            if !isCompact {
-                Text(String(format: "%.0f MB", proc.memoryMB))
-                    .font(Theme.body(ts))
-                    .foregroundStyle(proc.memoryMB > 1024 ? Theme.accentOrange : Theme.text2(ts))
-                    .monospacedDigit()
-                    .frame(width: 70, alignment: .trailing)
-            }
+            Text(String(format: "%.0f MB", proc.memoryMB))
+                .font(Theme.body(ts))
+                .foregroundStyle(proc.memoryMB > 1024 ? Theme.accentOrange : Theme.text2(ts))
+                .monospacedDigit()
+                .frame(width: 70, alignment: .trailing)
         }
         .padding(.horizontal, 14)
         .padding(.vertical, 8)

--- a/Sources/EdgeControl/Widgets/System/ProcessListWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/ProcessListWidget.swift
@@ -38,6 +38,10 @@ public final class ProcessListWidget: DashboardWidget {
 private struct ProcessListWidgetView: View {
     @ObservedObject var service: ProcessMonitorService
     @Environment(\.themeSettings) private var ts
+    @EnvironmentObject private var model: AppModel
+    // Tapping a column header re-sorts live, overriding the configured
+    // default for this on-screen session; tap again to flip direction.
+    @State private var tappedSort: (memory: Bool, ascending: Bool)?
     let sortByMemory: Bool
     /// nil = fit rows to the widget height; a number pins the count.
     let fixedRows: Int?
@@ -54,10 +58,8 @@ private struct ProcessListWidgetView: View {
             HStack {
                 Text("APP")
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Text("CPU")
-                    .frame(width: 70, alignment: .trailing)
-                Text("MEM")
-                    .frame(width: 70, alignment: .trailing)
+                sortHeader("CPU", memory: false)
+                sortHeader("MEM", memory: true)
             }
             .font(Theme.label(ts))
             .foregroundStyle(Theme.text3(ts))
@@ -75,9 +77,12 @@ private struct ProcessListWidgetView: View {
                 } else {
                     let fitCount = min(max(Int(geo.size.height / rowHeight), 3), 16)
                     let maxCount = fixedRows ?? fitCount
-                    let ranked = sortByMemory
-                        ? service.topProcesses.sorted { $0.memoryMB > $1.memoryMB }
-                        : service.topProcesses
+                    let memSort = tappedSort?.memory ?? sortByMemory
+                    let ascending = tappedSort?.ascending ?? false
+                    let ranked = service.topProcesses.sorted {
+                        let (a, b) = memSort ? ($0.memoryMB, $1.memoryMB) : ($0.cpuPercent, $1.cpuPercent)
+                        return ascending ? a < b : a > b
+                    }
                     let visible = Array(ranked.prefix(maxCount))
                     // Scrolls only when a pinned row count exceeds the height.
                     TouchScrollView {
@@ -94,6 +99,24 @@ private struct ProcessListWidgetView: View {
             }
         }
         .widgetCard()
+    }
+
+    private func sortHeader(_ label: String, memory: Bool) -> some View {
+        let memSort = tappedSort?.memory ?? sortByMemory
+        let ascending = tappedSort?.ascending ?? false
+        let active = memSort == memory
+        return Text(active ? label + (ascending ? " ▲" : " ▼") : label)
+            .foregroundStyle(active ? Theme.text1(ts) : Theme.text3(ts))
+            .frame(width: 70, alignment: .trailing)
+            .touchTappable(id: "proc-sort-\(label)", registry: model.touchService.zoneRegistry) {
+                Task { @MainActor in
+                    if active {
+                        tappedSort = (memory, !ascending)
+                    } else {
+                        tappedSort = (memory, false)
+                    }
+                }
+            }
     }
 
     private func processRow(_ proc: ProcessInfo_EC) -> some View {

--- a/Sources/EdgeControl/Widgets/System/ProcessListWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/ProcessListWidget.swift
@@ -12,7 +12,10 @@ public final class ProcessListWidget: DashboardWidget {
     public let defaultSize = WidgetSize.size(6, 4)
 
     public let configSchema: [ConfigSchemaEntry] = [
-        ConfigSchemaEntry(key: "sortBy", label: "Sort By", type: .picker, defaultValue: .string("cpu")),
+        ConfigSchemaEntry(key: "sortBy", label: "Sort By", type: .picker, defaultValue: .string("cpu"), options: ["cpu", "memory"]),
+        // "auto" fills whatever height the widget has; a number pins the row
+        // count and scrolls past it.
+        ConfigSchemaEntry(key: "rows", label: "Rows", type: .picker, defaultValue: .string("auto"), options: ["auto", "4", "6", "8", "10", "12"]),
     ]
     public let defaultColors = WidgetColors(primary: .purple, secondary: .cyan)
 
@@ -24,13 +27,20 @@ public final class ProcessListWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        ProcessListWidgetView(service: service)
+        ProcessListWidgetView(
+            service: service,
+            sortByMemory: config.string("sortBy", default: "cpu") == "memory",
+            fixedRows: Int(config.string("rows", default: "auto"))
+        )
     }
 }
 
 private struct ProcessListWidgetView: View {
     @ObservedObject var service: ProcessMonitorService
     @Environment(\.themeSettings) private var ts
+    let sortByMemory: Bool
+    /// nil = fit rows to the widget height; a number pins the count.
+    let fixedRows: Int?
 
     // Row = 26pt icon + 2x8pt vertical padding + 1pt divider.
     private let rowHeight: CGFloat = 43
@@ -63,17 +73,22 @@ private struct ProcessListWidgetView: View {
                         .foregroundStyle(Theme.text3(ts))
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else {
-                    // Service publishes at most 5 processes, so cap there rather than 12.
-                    let maxCount = min(max(Int(geo.size.height / rowHeight), 3), 12)
-                    let visible = Array(service.topProcesses.prefix(maxCount))
-                    VStack(spacing: 0) {
-                        ForEach(visible) { proc in
-                            processRow(proc)
-                            if proc.id != visible.last?.id {
-                                Divider().background(Theme.border(ts)).padding(.leading, 50)
+                    let fitCount = min(max(Int(geo.size.height / rowHeight), 3), 12)
+                    let maxCount = fixedRows ?? fitCount
+                    let ranked = sortByMemory
+                        ? service.topProcesses.sorted { $0.memoryMB > $1.memoryMB }
+                        : service.topProcesses
+                    let visible = Array(ranked.prefix(maxCount))
+                    // Scrolls only when a pinned row count exceeds the height.
+                    TouchScrollView {
+                        VStack(spacing: 0) {
+                            ForEach(visible) { proc in
+                                processRow(proc)
+                                if proc.id != visible.last?.id {
+                                    Divider().background(Theme.border(ts)).padding(.leading, 50)
+                                }
                             }
                         }
-                        Spacer(minLength: 0)
                     }
                 }
             }

--- a/Sources/EdgeControl/Widgets/System/StorageBarsWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/StorageBarsWidget.swift
@@ -21,7 +21,13 @@ public final class StorageBarsWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        StorageBarsWidgetView(metricsService: metricsService, isCompact: size.height <= 2)
+        // Full ring needs 3 rows, or 2 rows when at least 4 columns wide;
+        // smaller cells fall back to the bar-only layout.
+        StorageBarsWidgetView(
+            metricsService: metricsService,
+            isCompact: size.height == 1 || (size.height == 2 && size.width <= 3),
+            isBar: size.height == 1
+        )
     }
 }
 
@@ -29,6 +35,7 @@ private struct StorageBarsWidgetView: View {
     @ObservedObject var metricsService: SystemMetricsService
     @Environment(\.themeSettings) private var ts
     let isCompact: Bool
+    let isBar: Bool
 
     var body: some View {
         let m = metricsService.latest
@@ -43,6 +50,7 @@ private struct StorageBarsWidgetView: View {
 
             if let m {
                 if isCompact {
+                    if !isBar { Spacer(minLength: 0) }
                     VStack(spacing: 4) {
                         GeometryReader { geo in
                             ZStack(alignment: .leading) {
@@ -62,42 +70,50 @@ private struct StorageBarsWidgetView: View {
                                 .foregroundStyle(Theme.text2(ts))
                         }
                     }
+                    Spacer(minLength: 0)
                 } else {
-                    HStack(spacing: 16) {
-                        ZStack {
-                            Circle()
-                                .trim(from: 0, to: 1)
-                                .stroke(Color.white.opacity(0.08), style: StrokeStyle(lineWidth: 14, lineCap: .round))
-                                .rotationEffect(.degrees(-90))
-                            Circle()
-                                .trim(from: 0, to: m.storageUsedPercent / 100)
-                                .stroke(
-                                    AngularGradient(colors: [primary, secondary], center: .center),
-                                    style: StrokeStyle(lineWidth: 14, lineCap: .round)
-                                )
-                                .rotationEffect(.degrees(-90))
-                            VStack(spacing: 2) {
-                                Text(String(format: "%.0f%%", m.storageUsedPercent))
-                                    .font(Theme.value(ts))
-                                    .foregroundStyle(Theme.text1(ts))
-                                Text("USED")
-                                    .font(Theme.caption(ts))
-                                    .foregroundStyle(Theme.text2(ts))
+                    GeometryReader { geo in
+                        // Ring fills the cell height, leaving ~45% of the width for labels.
+                        let side = min(geo.size.height, geo.size.width * 0.55)
+                        let ringWidth = min(max(12, side * 0.1), 22)
+                        HStack(spacing: 16) {
+                            ZStack {
+                                Circle()
+                                    .trim(from: 0, to: 1)
+                                    .stroke(Color.white.opacity(0.08), style: StrokeStyle(lineWidth: ringWidth, lineCap: .round))
+                                    .rotationEffect(.degrees(-90))
+                                Circle()
+                                    .trim(from: 0, to: m.storageUsedPercent / 100)
+                                    .stroke(
+                                        AngularGradient(colors: [primary, secondary], center: .center),
+                                        style: StrokeStyle(lineWidth: ringWidth, lineCap: .round)
+                                    )
+                                    .rotationEffect(.degrees(-90))
+                                VStack(spacing: 2) {
+                                    Text(String(format: "%.0f%%", m.storageUsedPercent))
+                                        .font(Theme.value(ts))
+                                        .foregroundStyle(Theme.text1(ts))
+                                    Text("USED")
+                                        .font(Theme.caption(ts))
+                                        .foregroundStyle(Theme.text2(ts))
+                                }
+                            }
+                            // Stroke centers on the path; inset so it stays inside the frame.
+                            .padding(ringWidth / 2)
+                            .frame(width: side, height: side)
+
+                            VStack(alignment: .leading, spacing: 8) {
+                                storageLabel("USED", value: String(format: "%.0f GB", m.storageUsedGB), color: primary)
+                                storageLabel("FREE", value: String(format: "%.0f GB", m.storageTotalGB - m.storageUsedGB), color: tertiary)
+                                storageLabel("TOTAL", value: String(format: "%.0f GB", m.storageTotalGB), color: Theme.text2(ts))
                             }
                         }
-                        .frame(maxWidth: 140, maxHeight: 140)
-                        .aspectRatio(1, contentMode: .fit)
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            storageLabel("USED", value: String(format: "%.0f GB", m.storageUsedGB), color: primary)
-                            storageLabel("FREE", value: String(format: "%.0f GB", m.storageTotalGB - m.storageUsedGB), color: tertiary)
-                            storageLabel("TOTAL", value: String(format: "%.0f GB", m.storageTotalGB), color: Theme.text2(ts))
-                        }
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
                 }
+            } else {
+                Spacer(minLength: 0)
             }
-
-            Spacer(minLength: 0)
         }
         .padding(isCompact ? Theme.compactPadding : Theme.widgetPadding)
         .widgetCard()

--- a/Sources/EdgeControl/Widgets/System/StorageBarsWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/StorageBarsWidget.swift
@@ -21,11 +21,11 @@ public final class StorageBarsWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        // Full ring needs 3 rows, or 2 rows when at least 4 columns wide;
-        // smaller cells fall back to the bar-only layout.
+        // The ring scales itself to the cell, so every multi-row size keeps
+        // the ring look; only single-row placements fall back to the bar.
         StorageBarsWidgetView(
             metricsService: metricsService,
-            isCompact: size.height == 1 || (size.height == 2 && size.width <= 3),
+            isCompact: size.height == 1,
             isBar: size.height == 1
         )
     }

--- a/Sources/EdgeControl/Widgets/System/StorageBarsWidget.swift
+++ b/Sources/EdgeControl/Widgets/System/StorageBarsWidget.swift
@@ -7,7 +7,7 @@ public final class StorageBarsWidget: DashboardWidget {
     public let iconName = "externaldrive"
     public let category: WidgetCategory = .system
     public let requiredServices: Set<ServiceKey> = [.metrics]
-    public let supportedSizes = WidgetSizeRange(min: .size(3, 2), max: .size(8, 4))
+    public let supportedSizes = WidgetSizeRange(min: .size(2, 1), max: .size(8, 4))
     public let defaultSize = WidgetSize.size(4, 3)
 
     public let configSchema: [ConfigSchemaEntry] = []

--- a/Sources/EdgeControl/Widgets/Temperature/CPUTempWidget.swift
+++ b/Sources/EdgeControl/Widgets/Temperature/CPUTempWidget.swift
@@ -11,7 +11,6 @@ public final class CPUTempWidget: DashboardWidget {
     public let defaultSize = WidgetSize.size(3, 3)
 
     public let configSchema: [ConfigSchemaEntry] = [
-        ConfigSchemaEntry(key: "unit", label: "Unit", type: .picker, defaultValue: .string("C")),
         ConfigSchemaEntry(key: "warningThreshold", label: "Warning Threshold", type: .stepper, defaultValue: .int(85)),
     ]
     public let defaultColors = WidgetColors(primary: .cyan)
@@ -47,7 +46,6 @@ public final class GPUTempWidget: DashboardWidget {
     public let defaultSize = WidgetSize.size(3, 3)
 
     public let configSchema: [ConfigSchemaEntry] = [
-        ConfigSchemaEntry(key: "unit", label: "Unit", type: .picker, defaultValue: .string("C")),
         ConfigSchemaEntry(key: "warningThreshold", label: "Warning Threshold", type: .stepper, defaultValue: .int(90)),
     ]
     public let defaultColors = WidgetColors(primary: .orange)

--- a/Sources/EdgeControl/Widgets/Temperature/CPUTempWidget.swift
+++ b/Sources/EdgeControl/Widgets/Temperature/CPUTempWidget.swift
@@ -31,8 +31,7 @@ public final class CPUTempWidget: DashboardWidget {
             label: "CPU",
             defaultCoolColor: .cyan,
             isBar: size.height <= 1,
-            isChart: size.height == 2 && size.width >= 3,
-            isCompact: size.width <= 2 && size.height <= 2
+            isChart: size.height == 2 && size.width >= 3
         )
     }
 }
@@ -68,8 +67,7 @@ public final class GPUTempWidget: DashboardWidget {
             label: "GPU",
             defaultCoolColor: .orange,
             isBar: size.height <= 1,
-            isChart: size.height == 2 && size.width >= 3,
-            isCompact: size.width <= 2 && size.height <= 2
+            isChart: size.height == 2 && size.width >= 3
         )
     }
 }
@@ -90,7 +88,6 @@ private struct TempGaugeWidgetView: View {
     let defaultCoolColor: ThemeColor
     let isBar: Bool
     let isChart: Bool
-    let isCompact: Bool
 
     private var temp: Double? {
         switch sensor {
@@ -188,31 +185,19 @@ private struct TempGaugeWidgetView: View {
     // MARK: - Gauge Layout (2x2+)
 
     private var gaugeLayout: some View {
-        VStack(spacing: isCompact ? 4 : 8) {
+        VStack(spacing: 8) {
             if let temp {
                 let color = tempColor(temp)
 
-                if isCompact {
-                    VStack(spacing: 2) {
-                        Image(systemName: sensor == .cpu ? "cpu" : "gpu")
-                            .font(.system(size: 18 * ts.fontScale))
-                            .foregroundStyle(color)
-                        Text(units.degrees(fromCelsius: temp))
-                            .font(Theme.value(ts))
-                            .foregroundStyle(color)
-                            .monospacedDigit()
-                    }
-                } else {
-                    RadialGaugeView(
-                        value: temp,
-                        maxValue: 110,
-                        label: label,
-                        displayValue: units.temperatureText(fromCelsius: temp),
-                        unit: "",
-                        accentColor: color,
-                        showLabel: true
-                    )
-                }
+                RadialGaugeView(
+                    value: temp,
+                    maxValue: 110,
+                    label: label,
+                    displayValue: units.temperatureText(fromCelsius: temp),
+                    unit: "",
+                    accentColor: color,
+                    showLabel: true
+                )
             } else {
                 Image(systemName: sensor == .cpu ? "cpu" : "gpu")
                     .font(.system(size: 24 * ts.fontScale))

--- a/Sources/EdgeControl/Widgets/Temperature/PerCoreTempWidget.swift
+++ b/Sources/EdgeControl/Widgets/Temperature/PerCoreTempWidget.swift
@@ -21,7 +21,7 @@ public final class PerCoreTempWidget: DashboardWidget {
 
     @MainActor
     public func body(size: WidgetSize, config: WidgetConfig) -> any View {
-        PerCoreTempWidgetView(service: service, columns: size.width >= 8 ? 2 : 1)
+        PerCoreTempWidgetView(service: service, size: size)
     }
 }
 
@@ -29,7 +29,24 @@ private struct PerCoreTempWidgetView: View {
     @ObservedObject var service: SMCService
     @Environment(\.themeSettings) private var ts
     @Environment(\.unitSystem) private var units
-    let columns: Int
+    let size: WidgetSize
+
+    // Row geometry: coreRow fixed frame + VStack spacing; header title line + vertical padding.
+    private static let rowHeight: CGFloat = 18
+    private static let rowSpacing: CGFloat = 2
+    private static let headerChrome: CGFloat = 34
+
+    private var columns: Int {
+        let count = service.cpuCoreTemps.count
+        let available = CGFloat(size.height) * GridConstants.cellHeight - Self.headerChrome
+        let rowsThatFit = max(1, Int((available + Self.rowSpacing) / (Self.rowHeight + Self.rowSpacing)))
+        let maxByWidth = size.width >= 6 ? 2 : 1
+        for cols in 1...maxByWidth where (count + cols - 1) / cols <= rowsThatFit {
+            return cols
+        }
+        // Even maxByWidth columns overflow: keep width-only choice, TouchScrollView scrolls the rest.
+        return size.width >= 8 ? 2 : 1
+    }
 
     private var primary: Color { Theme.widgetPrimary("per-core-temp", ts: ts, default: .cyan) }
     private var secondary: Color { Theme.widgetSecondary("per-core-temp", ts: ts, default: .green) ?? Theme.accentGreen }

--- a/Sources/EdgeControl/Widgets/Temperature/SSDTempWidget.swift
+++ b/Sources/EdgeControl/Widgets/Temperature/SSDTempWidget.swift
@@ -27,8 +27,7 @@ public final class SSDTempWidget: DashboardWidget {
             service: service,
             showLabel: config.bool("showLabel", default: true),
             isBar: size.height <= 1,
-            isChart: size.height == 2 && size.width >= 3,
-            isCompact: size.width <= 2 && size.height <= 2
+            isChart: size.height == 2 && size.width >= 3
         )
     }
 }
@@ -40,7 +39,6 @@ private struct SSDTempWidgetView: View {
     let showLabel: Bool
     let isBar: Bool
     let isChart: Bool
-    let isCompact: Bool
 
     private var temp: Double? { service.ssdTemperature }
 
@@ -121,31 +119,19 @@ private struct SSDTempWidgetView: View {
     }
 
     private var gaugeLayout: some View {
-        VStack(spacing: isCompact ? 4 : 8) {
+        VStack(spacing: 8) {
             if let temp {
                 let color = tempColor(temp)
 
-                if isCompact {
-                    VStack(spacing: 2) {
-                        Image(systemName: "internaldrive")
-                            .font(.system(size: 18 * ts.fontScale))
-                            .foregroundStyle(color)
-                        Text(units.degrees(fromCelsius: temp))
-                            .font(Theme.value(ts))
-                            .foregroundStyle(color)
-                            .monospacedDigit()
-                    }
-                } else {
-                    RadialGaugeView(
-                        value: temp,
-                        maxValue: 100,
-                        label: "SSD",
-                        displayValue: units.temperatureText(fromCelsius: temp),
-                        unit: "",
-                        accentColor: color,
-                        showLabel: showLabel
-                    )
-                }
+                RadialGaugeView(
+                    value: temp,
+                    maxValue: 100,
+                    label: "SSD",
+                    displayValue: units.temperatureText(fromCelsius: temp),
+                    unit: "",
+                    accentColor: color,
+                    showLabel: showLabel
+                )
             } else {
                 Image(systemName: "internaldrive")
                     .font(.system(size: 24 * ts.fontScale))

--- a/Sources/EdgeControlWidgets/Providers/PluginWidgetProvider.swift
+++ b/Sources/EdgeControlWidgets/Providers/PluginWidgetProvider.swift
@@ -55,7 +55,9 @@ struct PluginWidgetEntry: TimelineEntry, Sendable {
     let date: Date
     let pluginId: String?
     let pluginName: String?
-    let snapshotImage: NSImage?
+    // NSImage is not Sendable; entries are only ever built and consumed on the
+    // main actor, so suppress the check rather than drop the conformance.
+    nonisolated(unsafe) let snapshotImage: NSImage?
     let isPlaceholder: Bool
 
     static let placeholder = PluginWidgetEntry(

--- a/Tests/EdgeControlTests/CI/RateLimitTrackingTransportTests.swift
+++ b/Tests/EdgeControlTests/CI/RateLimitTrackingTransportTests.swift
@@ -72,7 +72,7 @@ final class RateLimitTrackingTransportTests: XCTestCase {
         XCTAssertNil(a.rateLimit(forHost: "git.example.dev"))
     }
 
-    func testSettingsRendersQuotaWithReset() {
+    @MainActor func testSettingsRendersQuotaWithReset() {
         // Fixed `now`, so the assertion cannot depend on how long the test took
         // to reach this line.
         let now = Date(timeIntervalSince1970: 1_800_000_000)
@@ -89,7 +89,7 @@ final class RateLimitTrackingTransportTests: XCTestCase {
     }
 
     /// Under a minute must read as "resetting", not "0m".
-    func testQuotaResetWithinAMinute() {
+    @MainActor func testQuotaResetWithinAMinute() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let soon = CIRateLimit(limit: 60, remaining: 0, resetsAt: now.addingTimeInterval(20))
         XCTAssertEqual(CICDSettingsView.quotaText(soon, now: now), "0/60 · resetting")

--- a/Tests/EdgeControlTests/LayoutEngineTests.swift
+++ b/Tests/EdgeControlTests/LayoutEngineTests.swift
@@ -130,4 +130,37 @@ final class LayoutEngineTests: XCTestCase {
             "orders have to stay contiguous or sortedPages stops matching the array"
         )
     }
+
+    // MARK: - Edit session (staged overlaps)
+
+    func testEditingAllowsOverlapAsAStagingState() throws {
+        XCTAssertNotNil(
+            engine.placeWidget(pageId: pageId, widgetId: "cpu-gauge", col: 0, row: 0, width: 4, height: 3)
+        )
+        engine.isEditing = true
+
+        // Place, move and resize onto occupied cells all succeed mid-edit.
+        let staged = engine.placeWidget(pageId: pageId, widgetId: "memory-gauge", col: 2, row: 1, width: 4, height: 3)
+        XCTAssertNotNil(staged)
+        XCTAssertTrue(engine.moveWidget(pageId: pageId, instanceId: try XCTUnwrap(staged), toCol: 0, toRow: 0))
+        XCTAssertTrue(engine.resizeWidget(pageId: pageId, instanceId: try XCTUnwrap(staged), newWidth: 5, newHeight: 3))
+
+        XCTAssertTrue(engine.hasOverlaps)
+        XCTAssertEqual(engine.overlappingInstanceIds(pageId: pageId).count, 2)
+
+        // Off-grid stays refused even while editing.
+        XCTAssertFalse(engine.moveWidget(pageId: pageId, instanceId: try XCTUnwrap(staged), toCol: 50, toRow: 0))
+    }
+
+    func testEndingEditRestoresStrictPlacement() {
+        engine.isEditing = true
+        engine.isEditing = false
+        XCTAssertNotNil(
+            engine.placeWidget(pageId: pageId, widgetId: "cpu-gauge", col: 0, row: 0, width: 4, height: 3)
+        )
+        XCTAssertNil(
+            engine.placeWidget(pageId: pageId, widgetId: "memory-gauge", col: 2, row: 1, width: 4, height: 3)
+        )
+        XCTAssertFalse(engine.hasOverlaps)
+    }
 }

--- a/Tests/EdgeControlTests/LayoutEngineTests.swift
+++ b/Tests/EdgeControlTests/LayoutEngineTests.swift
@@ -10,8 +10,10 @@ final class LayoutEngineTests: XCTestCase {
     private var engine: LayoutEngine!
     private var pageId: String!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    // XCTest's throwing set-up hooks are nonisolated, so on a @MainActor
+    // test case they cannot touch the main-actor state they exist to build.
+    // The async hooks inherit the class's isolation, so use those instead.
+    override func setUp() async throws {
         directory = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("LayoutEngineTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -22,11 +24,10 @@ final class LayoutEngineTests: XCTestCase {
         pageId = engine.document.pages[0].id
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() async throws {
         engine = nil
         try? FileManager.default.removeItem(at: directory)
         directory = nil
-        try super.tearDownWithError()
     }
 
     private var widgets: [WidgetPlacement] { engine.document.pages[0].widgets }

--- a/Tests/EdgeControlTests/LayoutEngineTests.swift
+++ b/Tests/EdgeControlTests/LayoutEngineTests.swift
@@ -163,4 +163,21 @@ final class LayoutEngineTests: XCTestCase {
         )
         XCTAssertFalse(engine.hasOverlaps)
     }
+
+    // MARK: - Page reordering
+
+    func testMovingPagesKeepsTheVisiblePageVisible() {
+        engine.document.pages = [
+            PageConfig(name: "A", order: 0),
+            PageConfig(name: "B", order: 1),
+            PageConfig(name: "C", order: 2),
+        ]
+        engine.currentPageIndex = 1  // viewing B
+
+        // Move A to the end; B shifts to index 0 and must stay on screen.
+        engine.movePage(id: engine.document.pages[0].id, toOrder: 2)
+
+        XCTAssertEqual(engine.sortedPages.map(\.name), ["B", "C", "A"])
+        XCTAssertEqual(engine.sortedPages[engine.currentPageIndex].name, "B")
+    }
 }


### PR DESCRIPTION
## Stack 7 of 7 — builds on #14

**Incremental diff (just this PR's changes):** https://github.com/jondkinney/edgecontrol/compare/pr6-reminders-widget...pr7-sticky-note

### What this does

Adds a **Sticky Note** widget edited in place on the dashboard — a real rich-text surface, not a plain-text box, and with no edit/view mode toggle: you just type.

**Markdown-lite typing.** Headings, bullets, numbered lists and `[ ]` checkboxes form as you type, with the conversions deferred so they never fight the caret. Ordered lists renumber themselves; list text aligns in one column with a tight marker gutter; Enter on an empty marker ends the list.

**Checkboxes** are custom-drawn, sized above the body text while keeping the caret body-sized next to them, and toggle by click/tap or ⌘Return — preserving the line's indent level.

**Links**: paste a URL over a selection to link it; Enter inside a link opens it.

**Appearance** is configurable per note — font family and size, color, and opacity — with defaults chosen to read well on a dim kiosk display (18pt mono, soft white, 0.5 opacity).

An **Edit menu** is added to the app so the standard editing shortcuts work at all — the kiosk previously had no menu to host them.

### Verification

`** TEST SUCCEEDED **` — 90 tests, 0 failures. The editor was exercised by hand across list/checkbox/link transitions, since it is `NSTextView` behavior that unit tests do not usefully cover.

### Note on scope

This is the largest PR in the stack (28 commits) and is almost entirely confined to `StickyNoteWidget.swift`. It is last in the stack precisely because it is the most self-contained — dropping it costs you nothing else.

---

Targets `main` per GitHub's base-branch rule; until #9–#14 merge this diff also contains their commits.
