### PR TITLE
Count memory the way Activity Monitor does

### DIFF
--- a/EdgeControl.xcodeproj/project.pbxproj
+++ b/EdgeControl.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		BC9C21332908CE217BAD6109 /* github-orgs.json in Resources */ = {isa = PBXBuildFile; fileRef = D453C8CB6E8919896376088D /* github-orgs.json */; };
 		C00DE5F6C2A285BDD9A2EB66 /* AppLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10418B6B91599F07758AB415 /* AppLog.swift */; };
 		C2418CFE9BB9A03196699319 /* MemoryHistoryWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54719D274F7ACDD949ECE6B1 /* MemoryHistoryWidget.swift */; };
+		C6F2154BFCF7FCA1B6174699 /* MemoryReadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71703594497679F81897571A /* MemoryReadingTests.swift */; };
 		C95EFF669BFD61A25DBEBC55 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB321E4A1BF145B8BAAE20D5 /* SettingsView.swift */; };
 		CA451229F99B09583CFC76E2 /* PluginManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67C08C5CA9435270274DCC6A /* PluginManagerView.swift */; };
 		CD37941FA72921E96249BA8B /* WindowPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FA253FD7E072776DDBB0FD /* WindowPlacement.swift */; };
@@ -255,6 +256,7 @@
 		6EA67D6152E0568A1CDD0A5F /* WiFiProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WiFiProvider.swift; sourceTree = "<group>"; };
 		70ECE563C838DF68844481D7 /* SystemGaugeWidgetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemGaugeWidgetView.swift; sourceTree = "<group>"; };
 		70FEAAA8B09E3342724D9B5C /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		71703594497679F81897571A /* MemoryReadingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryReadingTests.swift; sourceTree = "<group>"; };
 		7175879BD7EAFC1CB360F629 /* BluetoothWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BluetoothWidget.swift; sourceTree = "<group>"; };
 		71FA253FD7E072776DDBB0FD /* WindowPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowPlacement.swift; sourceTree = "<group>"; };
 		722485033F676CCBCFB190DF /* TouchButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchButton.swift; sourceTree = "<group>"; };
@@ -578,6 +580,7 @@
 				88D41E20A1F2AF5648229E3B /* LayoutConfigTests.swift */,
 				97E43C87A7DE46C0837CA55B /* LayoutEngineTests.swift */,
 				60A1AA058F19A28213132880 /* LayoutStoreTests.swift */,
+				71703594497679F81897571A /* MemoryReadingTests.swift */,
 				7BDFD72C902F1B895FC4E4AC /* UnitSystemTests.swift */,
 			);
 			path = EdgeControlTests;
@@ -996,6 +999,7 @@
 				303445182C922B7EC2923508 /* LayoutConfigTests.swift in Sources */,
 				537CD61475EB89D7FB19E902 /* LayoutEngineTests.swift in Sources */,
 				F0B931A1C432E07FDE4E3660 /* LayoutStoreTests.swift in Sources */,
+				C6F2154BFCF7FCA1B6174699 /* MemoryReadingTests.swift in Sources */,
 				93E3BDABAA934EF0D339DB0C /* RateLimitTrackingTransportTests.swift in Sources */,
 				367DC444F94891E30BA706C5 /* StubTransport.swift in Sources */,
 				50D123F4E3361D68BA400ED4 /* UnitSystemTests.swift in Sources */,

--- a/Sources/EdgeControl/Services/SystemMetricsService.swift
+++ b/Sources/EdgeControl/Services/SystemMetricsService.swift
@@ -7,6 +7,44 @@ public struct CoreUsage: Identifiable, Equatable {
     public let usage: Double // 0-100
 }
 
+/// The memory arithmetic, kept apart from the `host_statistics64` call so it can
+/// be exercised with known page counts.
+struct MemoryReading {
+    let usedGB: Double
+    let usedPercent: Double
+    let pressurePercent: Double
+
+    init(stats: vm_statistics64, pageSize: Double, physicalBytes: Double) {
+        guard physicalBytes > 0 else {
+            usedGB = 0
+            usedPercent = 0
+            pressurePercent = 0
+            return
+        }
+
+        // Activity Monitor's "Memory Used" is app memory + wired + compressed. File-backed
+        // and purgeable pages are cache the kernel hands back the moment anything needs
+        // the space, so counting them as used overstates the figure by the size of the
+        // cache — tens of gigabytes on a machine with room to spare.
+        let appPages = max(0, Double(stats.internal_page_count) - Double(stats.purgeable_count))
+        let wiredPages = Double(stats.wire_count)
+        let compressedPages = Double(stats.compressor_page_count)
+        let usedBytes = (appPages + wiredPages + compressedPages) * pageSize
+        usedGB = max(0, usedBytes / (1024 * 1024 * 1024))
+        usedPercent = Self.percent(of: usedBytes, in: physicalBytes)
+
+        // Pressure is what the kernel cannot reclaim, which is the figure
+        // `memory_pressure` reports as unavailable. Deriving it from free pages instead
+        // leaves it a second copy of the used percentage, pinned high and blind to a
+        // real spike.
+        pressurePercent = Self.percent(of: (wiredPages + compressedPages) * pageSize, in: physicalBytes)
+    }
+
+    private static func percent(of bytes: Double, in total: Double) -> Double {
+        min(max(bytes / total * 100, 0), 100)
+    }
+}
+
 @MainActor
 public final class SystemMetricsService: ObservableObject {
     @Published public private(set) var latest: SystemMetrics?
@@ -117,11 +155,14 @@ public final class SystemMetricsService: ObservableObject {
         let pressurePercent: Double
         let usedGB: Double
         if result == KERN_SUCCESS {
-            let freePages = Double(stats.free_count + stats.speculative_count)
-            let usedBytes = Double(ProcessInfo.processInfo.physicalMemory) - (freePages * pageSize)
-            usedGB = max(0, usedBytes / (1024 * 1024 * 1024))
-            usedPercent = min(max((usedGB / totalMemoryGB) * 100, 0), 100)
-            pressurePercent = min(max(100 - ((freePages * pageSize) / Double(ProcessInfo.processInfo.physicalMemory) * 100), 0), 100)
+            let reading = MemoryReading(
+                stats: stats,
+                pageSize: pageSize,
+                physicalBytes: Double(ProcessInfo.processInfo.physicalMemory)
+            )
+            usedGB = reading.usedGB
+            usedPercent = reading.usedPercent
+            pressurePercent = reading.pressurePercent
         } else {
             usedGB = latest?.memoryUsedGB ?? 0
             usedPercent = latest?.memoryUsedPercent ?? 0

--- a/Tests/EdgeControlTests/MemoryReadingTests.swift
+++ b/Tests/EdgeControlTests/MemoryReadingTests.swift
@@ -1,0 +1,107 @@
+import Darwin.Mach
+import XCTest
+@testable import EdgeControl
+
+final class MemoryReadingTests: XCTestCase {
+    private let pageSize: Double = 16384
+    private let physicalBytes: Double = 137_438_953_472 // 128 GB
+
+    /// Page counts read from `vm_stat` on a 128 GB machine that Activity Monitor
+    /// and iStat Menus both reported as 63% used, 7% pressure.
+    private func liveStats() -> vm_statistics64 {
+        var stats = vm_statistics64()
+        stats.free_count = 703_644
+        stats.active_count = 3_580_256
+        stats.inactive_count = 3_503_250
+        stats.speculative_count = 75_851
+        stats.wire_count = 425_874
+        stats.purgeable_count = 316_230
+        stats.external_page_count = 2_167_119
+        stats.internal_page_count = 5_308_468 // anonymous 4,992,238 + purgeable
+        stats.compressor_page_count = 39_382
+        return stats
+    }
+
+    func testUsedMatchesActivityMonitor() {
+        let reading = MemoryReading(stats: liveStats(), pageSize: pageSize, physicalBytes: physicalBytes)
+        XCTAssertEqual(reading.usedGB, 83.3, accuracy: 0.1)
+        XCTAssertEqual(reading.usedPercent, 65, accuracy: 1)
+    }
+
+    /// The bug this replaces: treating everything that was not free or speculative
+    /// as used counted the file cache too, and reported 116 GB — 91% — on the very
+    /// same sample. Anything above 70% here means the cache has crept back in.
+    func testTheFileCacheIsNotCountedAsUsed() {
+        let reading = MemoryReading(stats: liveStats(), pageSize: pageSize, physicalBytes: physicalBytes)
+        XCTAssertLessThan(reading.usedPercent, 70)
+        XCTAssertLessThan(reading.usedGB, 90)
+    }
+
+    func testPurgeablePagesComeOutOfAppMemory() {
+        var stats = liveStats()
+        let withPurgeable = MemoryReading(stats: stats, pageSize: pageSize, physicalBytes: physicalBytes)
+        stats.purgeable_count = 0
+        let withoutPurgeable = MemoryReading(stats: stats, pageSize: pageSize, physicalBytes: physicalBytes)
+        XCTAssertEqual(
+            withoutPurgeable.usedGB - withPurgeable.usedGB,
+            316_230 * pageSize / (1024 * 1024 * 1024),
+            accuracy: 0.001
+        )
+    }
+
+    func testPressureCountsOnlyWiredAndCompressedPages() {
+        let reading = MemoryReading(stats: liveStats(), pageSize: pageSize, physicalBytes: physicalBytes)
+        XCTAssertEqual(reading.pressurePercent, 5.5, accuracy: 0.5)
+    }
+
+    /// Pressure and usage answer different questions. Filling the rest of the
+    /// machine with reclaimable cache moves the gauge that reports usage and must
+    /// leave the one that reports pressure where it was — the old formula moved
+    /// both together, which is what left pressure pinned at 91%.
+    func testPressureDoesNotFollowTheCache() {
+        var stats = liveStats()
+        let before = MemoryReading(stats: stats, pageSize: pageSize, physicalBytes: physicalBytes)
+        stats.external_page_count += 700_000
+        stats.free_count = 3_644
+        stats.speculative_count = 0
+        let after = MemoryReading(stats: stats, pageSize: pageSize, physicalBytes: physicalBytes)
+        XCTAssertEqual(after.pressurePercent, before.pressurePercent, accuracy: 0.001)
+        XCTAssertEqual(after.usedPercent, before.usedPercent, accuracy: 0.001)
+    }
+
+    func testPressureRisesWithCompressedPages() {
+        var stats = liveStats()
+        let calm = MemoryReading(stats: stats, pageSize: pageSize, physicalBytes: physicalBytes)
+        stats.compressor_page_count = 2_000_000
+        let strained = MemoryReading(stats: stats, pageSize: pageSize, physicalBytes: physicalBytes)
+        XCTAssertGreaterThan(strained.pressurePercent, calm.pressurePercent + 20)
+    }
+
+    func testPercentagesStayInRange() {
+        var stats = vm_statistics64()
+        stats.wire_count = 90_000_000 // more pages than the machine has
+        stats.internal_page_count = 90_000_000
+        let reading = MemoryReading(stats: stats, pageSize: pageSize, physicalBytes: physicalBytes)
+        XCTAssertEqual(reading.usedPercent, 100)
+        XCTAssertEqual(reading.pressurePercent, 100)
+    }
+
+    /// `purgeable_count` can exceed `internal_page_count` between the two reads
+    /// inside the kernel's snapshot, and a negative page count would run the
+    /// gauge backwards.
+    func testMorePurgeableThanInternalPagesReadsAsZeroAppMemory() {
+        var stats = vm_statistics64()
+        stats.internal_page_count = 1_000
+        stats.purgeable_count = 5_000
+        let reading = MemoryReading(stats: stats, pageSize: pageSize, physicalBytes: physicalBytes)
+        XCTAssertEqual(reading.usedGB, 0)
+        XCTAssertEqual(reading.usedPercent, 0)
+    }
+
+    func testAZeroPhysicalSizeDoesNotProduceNaN() {
+        let reading = MemoryReading(stats: liveStats(), pageSize: pageSize, physicalBytes: 0)
+        XCTAssertEqual(reading.usedPercent, 0)
+        XCTAssertEqual(reading.pressurePercent, 0)
+        XCTAssertEqual(reading.usedGB, 0)
+    }
+}


### PR DESCRIPTION
## The bug

The memory gauge counts every page that is not free or speculative as used, which sweeps in the file cache. On a 128 GB machine it reads **116 GB / 91%** while Activity Monitor and iStat Menus both report **63%**:

| | EdgeControl 2.3.1 | Activity Monitor / iStat |
|---|---|---|
| Memory used | 116.0 GB — 91% | ~83 GB — 63% |
| Pressure | 91% | 7% |

The error scales with how much RAM the machine has spare to cache with, so it's worst on exactly the machines this dashboard is aimed at.

Memory pressure has a second problem: it's derived from the same free-page count, so it is effectively a duplicate of the used percentage. Both gauges move together and sit pinned near the top, which means a genuine pressure spike — the thing that gauge exists to show — has nowhere left to travel.

## The fix

`SystemMetricsService.currentMemorySnapshot()`:

- **Used** = app memory (`internal_page_count − purgeable_count`) + wired + compressed, the three figures Activity Monitor adds up. File-backed and purgeable pages are cache the kernel hands back on demand, so they aren't counted.
- **Pressure** = (wired + compressed) / physical — only what the kernel cannot reclaim, which is what `memory_pressure` reports as unavailable. On the sample above that gives 5% against iStat's 7%.

Incidentally this also drops a small double-count: `vm_statistics64.free_count` already includes speculative pages, so the old `free_count + speculative_count` counted them twice.

## Tests

The arithmetic moves into a `MemoryReading` struct so it can be exercised without reading the live host. `Tests/EdgeControlTests/MemoryReadingTests.swift` runs the `vm_stat` page counts from that 128 GB machine through it and pins used and pressure to what Activity Monitor showed, plus the edge cases (clamping, `purgeable_count > internal_page_count`, zero physical size). Reverting the source to the old formula fails them with exactly the 116.1 GB / 90.7% from the screenshot.

Behaviour is unchanged otherwise: same struct fields, same call site, same fallback to the previous sample when `host_statistics64` fails.

## One note

I could not run the suite on a clean `main` — on Xcode 16.4 / Swift 6, `main` fails to compile before any of this (`PluginWidgetProvider.swift:58`, non-Sendable `NSImage` in a `Sendable` struct, and main-actor isolation errors in `LayoutEngineTests`). I verified these tests with those build errors patched locally. Happy to send that as a separate PR if it would be useful.
